### PR TITLE
Adding collection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Built with Go - Mmock runs without installation on multiple platforms.
 
 * Easy mock definition via JSON or YAML
 * Variables in response (fake or request data, including regex support)
-* Persist request body to file and load response from file
+* Persist request body and load response from file or MongoDB
 * Ability to send message to AMQP server
 * Glob matching ( /a/b/* )
 * Match request by method, URL params, headers, cookies and bodies.
@@ -122,6 +122,7 @@ Mock definition:
 
 ```
 {
+	"description": "Some text that describes the intended usage of the current configuration",
 	"request": {
 		"method": "GET|POST|PUT|PATCH|...",
 		"path": "/your/path/*",
@@ -150,6 +151,7 @@ Mock definition:
 	},
 	"persist" : {
 		"entity" : "/users/user-{{request.url./your/path/(?P<value>\\d+)}}.json",
+		"collection" : "users",
         "actions"{
 			"delete":"true",
 			"append":"text",
@@ -208,7 +210,8 @@ To do a match with queryStringParameters, headers, cookies. All defined keys in 
 
 #### Persist (Optional)
 	
-* *entity*: The relative path from config-persist-path to the file where the response body to be loaded from. It allows vars.
+* *entity*: The relative path from config-persist-path to the file where the response body to be loaded from or the collection name and id if you are using MongoDB. It allows vars.
+* *collection*: Used for returning or deleting more than one record. Represents the relative path from config-persist-path to the folder or the name of the mongo collection from where the records should be selected. Regex or glob can be used for filtering entities as well. Examples for the usage of collections can be found [here](/config).
 * *actions*: Actions to take over the entity (Append,Write,Delete)
 
 #### Notify (Optional)
@@ -258,8 +261,10 @@ Request data:
  - response.body."regex to match value"
  - persist.entity.content
  - persist.entity.name
+ - persist.entity.name."regex to match value"
+ - persist.collection.content
 
-> Regex: The regex should contain a group named **value** which will be matched and its value will be returned. E.g. if we want to match the id from this url **`/your/path/4`** the regex should look like **`/your/path/(?P<value>\\d+)`**. Note that in *golang* the named regex group match need to contain a **P** symbol after the question mark. The regex should be prefixed either with **request.url.**, **request.body.** or **response.body.** considering your input.
+> Regex: The regex should contain a group named **value** which will be matched and its value will be returned. E.g. if we want to match the id from this url **`/your/path/4`** the regex should look like **`/your/path/(?P<value>\\d+)`**. Note that in *golang* the named regex group match need to contain a **P** symbol after the question mark. The regex should be prefixed either with **request.url.**, **request.body.** or **response.body.** considering your input. When setting the Persist.Collection field the regex can match multiple records from it's input, which is useful for cases like [users-delete-passingids.json](config/users-delete-passingids.json) 
 
 
 Fake data:

--- a/config/amqp.json
+++ b/config/amqp.json
@@ -1,32 +1,33 @@
 {  
-   "request":{  
-      "method":"POST",
-      "path":"/amqp/*.json"
-   },
-   "persist": {
+    "description": "Sends a message to an AMQP server after the content is persisted",
+    "request":{  
+        "method":"POST",
+        "path":"/amqp/*.json"
+    },
+    "persist": {
         "entity": "/user-{{request.url./amqp/(?P<value>\\d+)}}.json",
         "actions" : {
             "write" : "{{request.body}}",
             "append" : "{ \"id\": {{request.url./amqp/(?P<value>\\d+)}}, \"city\": \"{{ fake.City }}\" }"
         }
-   },
-   "response":{  
-      "statusCode":202,
-      "headers":{  
-         "Content-Type":[  
+    },
+    "response":{  
+        "statusCode":202,
+        "headers":{  
+            "Content-Type":[  
             "application/json"
-         ]
-      },
-      "body":"{{persist.entity.content}}"
-   },
-   "notify":{  
-      "amqp":{  
-         "url":"amqp://guest:guest@localhost:5672/myVHost",
-         "body":"{{persist.entity.content}}",
-         "delay":2,
-         "exchange":"myExchange",
-         "type":"MockType",
-         "correlationId":"9782b88f-0c6e-4879-8c23-4699785e6a95"
-      }
-   }
+            ]
+        },
+        "body":"{{persist.entity.content}}"
+    },
+    "notify":{  
+        "amqp":{  
+            "url":"amqp://guest:guest@localhost:5672/myVHost",
+            "body":"{{persist.entity.content}}",
+            "delay":2,
+            "exchange":"myExchange",
+            "type":"MockType",
+            "correlationId":"9782b88f-0c6e-4879-8c23-4699785e6a95"
+        }
+    }
 }

--- a/config/cookie.json
+++ b/config/cookie.json
@@ -1,4 +1,5 @@
 {
+	"description": "Checks for a given cookie in the request to match the configuration",
 	"request": {
 		"method": "GET",
 		"path": "/hello*",

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
+	"description": "Default endpoint for the root of the site",
 	"request": {
 		"method": "GET",
 		"path": "/"

--- a/config/hello.json
+++ b/config/hello.json
@@ -1,4 +1,5 @@
 {
+	"description": "Returns 'Hello world!' and sets the 'visit' cookie",
 	"request": {
 		"method": "GET",
 		"path": "/hello"

--- a/config/proxy.json
+++ b/config/proxy.json
@@ -1,9 +1,10 @@
 {
+	"description": "Example for proxy usage",
 	"request": {
 		"method": "GET",
 		"path": "/proxy/example"
 	},
 	"control": {
-        "proxyBaseURL":"http://www.mocky.io/v2/57e1b4d1110000b90556f51c"
+		"proxyBaseURL":"http://www.mocky.io/v2/57e1b4d1110000b90556f51c"
 	}
 }

--- a/config/query-string.json
+++ b/config/query-string.json
@@ -1,23 +1,24 @@
 {
-   "request":{
-      "method":"GET",
-      "path":"/search",
-      "queryStringParameters":{
-         "city":[
+    "description": "Example for checking query string parameters",
+    "request":{
+        "method":"GET",
+        "path":"/search",
+        "queryStringParameters":{
+            "city":[
             "Barcelona"
-         ],
-         "postal_code":[
+            ],
+            "postal_code":[
             "08902"
-         ]
-      }
-   },
-   "response":{
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
+            ]
+        }
+    },
+    "response":{
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
             "Content-type: text/xml"
-         ]
-      },
-      "body":"<resultsSummary><fullyMatching>30</fullyMatching><estimatedHits>30</estimatedHits><currStart>1</currStart>  <currEnd>10</currEnd>  <nextStart>11</nextStart></resultsSummary>"
-   }
+            ]
+        },
+        "body":"<resultsSummary><fullyMatching>30</fullyMatching><estimatedHits>30</estimatedHits><currStart>1</currStart>  <currEnd>10</currEnd>  <nextStart>11</nextStart></resultsSummary>"
+    }
 }

--- a/config/users-delete-collection.json
+++ b/config/users-delete-collection.json
@@ -1,0 +1,21 @@
+{  
+   "request":{  
+      "method":"DELETE",
+      "path":"/users"
+   },
+   "persist":{  
+      "collection":"users",
+      "actions":{  
+         "delete":"true"
+      }
+   },
+   "response":{  
+      "statusCode":200,
+      "headers":{  
+         "Content-Type":[  
+            "application/json"
+         ]
+      },
+      "body":"Files Deleted"
+   }
+}

--- a/config/users-delete-collection.json
+++ b/config/users-delete-collection.json
@@ -1,21 +1,22 @@
 {  
-   "request":{  
-      "method":"DELETE",
-      "path":"/users"
-   },
-   "persist":{  
-      "collection":"users",
-      "actions":{  
-         "delete":"true"
-      }
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"Files Deleted"
-   }
+    "description": "Deleting all the records from the 'users' collection",
+    "request":{  
+        "method":"DELETE",
+        "path":"/users"
+    },
+    "persist":{  
+        "collection":"users",
+        "actions":{  
+            "delete":"true"
+        }
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"Records Deleted"
+    }
 }

--- a/config/users-delete-multiple.json
+++ b/config/users-delete-multiple.json
@@ -1,0 +1,21 @@
+{  
+   "request":{  
+      "method":"DELETE",
+      "path":"/id-users/*"
+   },
+   "persist":{  
+      "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json",
+      "actions":{  
+         "delete":"true"
+      }
+   },
+   "response":{  
+      "statusCode":200,
+      "headers":{  
+         "Content-Type":[  
+            "application/json"
+         ]
+      },
+      "body":"File Deleted"
+   }
+}

--- a/config/users-delete-multiple.json
+++ b/config/users-delete-multiple.json
@@ -1,21 +1,22 @@
 {  
-   "request":{  
-      "method":"DELETE",
-      "path":"/id-users/*"
-   },
-   "persist":{  
-      "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json",
-      "actions":{  
-         "delete":"true"
-      }
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"File Deleted"
-   }
+    "description": "Deleting multiple persisted entities by multiple regex match from the url e.g. /id-users/1,2,3,4,5 ",    
+    "request":{  
+        "method":"DELETE",
+        "path":"/id-users/*"
+    },
+    "persist":{  
+        "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json",
+        "actions":{  
+            "delete":"true"
+        }
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"Records Deleted"
+    }
 }

--- a/config/users-delete-multiple.mixed.json
+++ b/config/users-delete-multiple.mixed.json
@@ -1,0 +1,19 @@
+{  
+    "description": "Deleting multiple persisted entities by multiple regex matches from the url and body. e.g. url: /mixed-entities/1,2 body: users,roles which will delete users/1.json, users/2.json, roles/1.json, roles/2.json",
+    "request":{  
+        "method":"DELETE",
+        "path":"/mixed-entities/*"
+    },
+    "persist":{  
+        "collection":"{{request.body.(?P<value>\\w+)}}/{{request.url.(?P<value>\\d+)}}.json"
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"{{persist.collection.content}}"
+    }
+}

--- a/config/users-delete-passingids.json
+++ b/config/users-delete-passingids.json
@@ -1,0 +1,22 @@
+{  
+   "request":{  
+      "method":"DELETE",
+      "path":"/passed-ids",
+      "body": "*"
+   },
+   "persist":{  
+      "collection":"users/user-{{request.body.(?P<value>\\d+)}}.json",
+      "actions":{  
+         "delete":"true"
+      }
+   },
+   "response":{  
+      "statusCode":200,
+      "headers":{  
+         "Content-Type":[  
+            "application/json"
+         ]
+      },
+      "body":"File Deleted"
+   }
+}

--- a/config/users-delete-passingids.json
+++ b/config/users-delete-passingids.json
@@ -1,22 +1,23 @@
 {  
-   "request":{  
-      "method":"DELETE",
-      "path":"/passed-ids",
-      "body": "*"
-   },
-   "persist":{  
-      "collection":"users/user-{{request.body.(?P<value>\\d+)}}.json",
-      "actions":{  
-         "delete":"true"
-      }
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"File Deleted"
-   }
+    "description": "Deleting multiple persisted entities by multiple regex match from the body e.g. url: '/passed-ids' with body 'deletedIds=1,2,3,4,5' . This can be used for mocking https://www.pingdom.com/resources/api#MethodDelete+Multiple+Checks",
+    "request":{  
+        "method":"DELETE",
+        "path":"/passed-ids",
+        "body": "*"
+    },
+    "persist":{  
+        "collection":"users/user-{{request.body.(?P<value>\\d+)}}.json",
+        "actions":{  
+            "delete":"true"
+        }
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"Records Deleted"
+    }
 }

--- a/config/users-delete.json
+++ b/config/users-delete.json
@@ -1,21 +1,22 @@
 {  
-   "request":{  
-      "method":"DELETE",
-      "path":"/users/*.json"
-   },
-   "persist":{  
-      "entity":"/users/user-{{request.url./users/(?P<value>\\d+)}}.json",
-      "actions":{  
-         "delete":"true"
-      }
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"File Deleted"
-   }
+    "description": "Deleting a persisted entity by matching the id from the url using regex",
+    "request":{  
+        "method":"DELETE",
+        "path":"/users/*.json"
+    },
+    "persist":{  
+        "entity":"/users/user-{{request.url./users/(?P<value>\\d+)}}.json",
+        "actions":{  
+            "delete":"true"
+        }
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"Record Deleted"
+    }
 }

--- a/config/users-get-collection.json
+++ b/config/users-get-collection.json
@@ -1,18 +1,19 @@
-{  
-   "request":{  
-      "method":"GET",
-      "path":"/users"
-   },
-   "persist":{  
-      "collection":"users"
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"{{persist.collection.content}}"
-   }
+{
+    "description": "Getting all the records from the 'users' collection",  
+    "request":{  
+        "method":"GET",
+        "path":"/users"
+    },
+    "persist":{  
+        "collection":"users"
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"{{persist.collection.content}}"
+    }
 }

--- a/config/users-get-collection.json
+++ b/config/users-get-collection.json
@@ -1,0 +1,18 @@
+{  
+   "request":{  
+      "method":"GET",
+      "path":"/users"
+   },
+   "persist":{  
+      "collection":"users"
+   },
+   "response":{  
+      "statusCode":200,
+      "headers":{  
+         "Content-Type":[  
+            "application/json"
+         ]
+      },
+      "body":"{{persist.collection.content}}"
+   }
+}

--- a/config/users-get-multiple.json
+++ b/config/users-get-multiple.json
@@ -1,18 +1,19 @@
 {  
-   "request":{  
-      "method":"GET",
-      "path":"/id-users/*"
-   },
-   "persist":{  
-      "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json"
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"{{persist.collection.content}}"
-   }
+    "description": "Getting multiple persisted entities by multiple regex match from the url e.g. /id-users/1,2,3,4,5 ",
+    "request":{  
+        "method":"GET",
+        "path":"/id-users/*"
+    },
+    "persist":{  
+        "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json"
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"{{persist.collection.content}}"
+    }
 }

--- a/config/users-get-multiple.json
+++ b/config/users-get-multiple.json
@@ -1,0 +1,18 @@
+{  
+   "request":{  
+      "method":"GET",
+      "path":"/id-users/*"
+   },
+   "persist":{  
+      "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json"
+   },
+   "response":{  
+      "statusCode":200,
+      "headers":{  
+         "Content-Type":[  
+            "application/json"
+         ]
+      },
+      "body":"{{persist.collection.content}}"
+   }
+}

--- a/config/users-get.json
+++ b/config/users-get.json
@@ -1,18 +1,19 @@
 {  
-   "request":{  
-      "method":"GET",
-      "path":"/users/*.json"
-   },
-   "persist":{  
-      "entity":"/users/user-{{request.url./users/(?P<value>\\d+)}}.json"
-   },
-   "response":{  
-      "statusCode":200,
-      "headers":{  
-         "Content-Type":[  
-            "application/json"
-         ]
-      },
-      "body":"{{persist.entity.content}}"
-   }
+    "description": "Gets a persisted entity by matching the id from the url using regex",
+    "request":{  
+        "method":"GET",
+        "path":"/users/*.json"
+    },
+    "persist":{  
+        "entity":"/users/user-{{request.url./users/(?P<value>\\d+)}}.json"
+    },
+    "response":{  
+        "statusCode":200,
+        "headers":{  
+            "Content-Type":[  
+                "application/json"
+            ]
+        },
+        "body":"{{persist.entity.content}}"
+    }
 }

--- a/config/users-post-generate-id.json
+++ b/config/users-post-generate-id.json
@@ -1,0 +1,22 @@
+{
+    "request": {
+        "method": "POST",
+        "path": "/users"
+    },
+    "persist": {
+        "entity": "/users/user-{{fake.Digits}}.json",
+        "actions" : {
+            "write" : "{{ request.body }}",
+            "append" : "{ \"id\": {{persist.entity.name./users/user\\-(?P<value>\\d+)\\.json}} }"
+        }
+    },
+    "response": {
+        "statusCode": 202,
+        "headers": {
+            "Content-Type": [
+                "application/json"
+            ]
+        },
+        "body":"{{ persist.entity.content }}"
+    }
+}

--- a/config/users-post-generate-id.json
+++ b/config/users-post-generate-id.json
@@ -1,4 +1,5 @@
 {
+    "description": "Creating a persisted entity generating id for the entity key and reuse it in the entity body",
     "request": {
         "method": "POST",
         "path": "/users"

--- a/config/users-post.json
+++ b/config/users-post.json
@@ -1,4 +1,5 @@
 {
+    "description": "Creating a persisted entity by matching the id from the url using regex and adding it in the persisted entity",
     "request": {
         "method": "POST",
         "path": "/users/*.json"

--- a/definition/file_definition.go
+++ b/definition/file_definition.go
@@ -89,11 +89,26 @@ func (fd *FileDefinition) WatchDir() {
 		log.Println("Hot mock file changing not available.")
 		return
 	}
+
 	err = watcher.Add(fd.Path)
 	if err != nil {
 		log.Printf("Hot mock file changing not available in folder: %s\n", fd.Path)
 		return
 	}
+
+	if err = filepath.Walk(fd.Path, func(path string, fileInfo os.FileInfo, err error) error {
+		if fileInfo.IsDir() {
+			err = watcher.Add(path)
+			if err != nil {
+				log.Printf("Hot mock file changing not available in folder: %s\n", fd.Path)
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return
+	}
+
 	go func() {
 		for {
 			select {

--- a/definition/mock.go
+++ b/definition/mock.go
@@ -22,10 +22,11 @@ type Notify struct {
 
 //Mock contains the user mock definition
 type Mock struct {
-	Name     string
-	Request  Request  `json:"request"`
-	Response Response `json:"response"`
-	Persist  Persist  `json:"persist"`
-	Notify   Notify   `json:"notify"`
-	Control  Control  `json:"control"`
+	Name        string
+	Description string   `json:"description"`
+	Request     Request  `json:"request"`
+	Response    Response `json:"response"`
+	Persist     Persist  `json:"persist"`
+	Notify      Notify   `json:"notify"`
+	Control     Control  `json:"control"`
 }

--- a/definition/mock.go
+++ b/definition/mock.go
@@ -8,10 +8,12 @@ type Control struct {
 }
 
 type Actions map[string]string
+
 type Persist struct {
-	Entity  string  `json:"entity"`
-	Actions Actions `json:"actions"`
-	Engine  string  `json:"engine"`
+	Entity     string  `json:"entity"`
+	Collection string  `json:"collection"`
+	Actions    Actions `json:"actions"`
+	Engine     string  `json:"engine"`
 }
 
 type Notify struct {

--- a/persist/entity_persister.go
+++ b/persist/entity_persister.go
@@ -2,7 +2,9 @@ package persist
 
 type EntityPersister interface {
 	Read(name string) (string, error)
+	ReadCollection(name string) (string, error)
 	Write(name, content string) error
 	Delete(name string) error
+	DeleteCollection(name string) error
 	GetName() string
 }

--- a/persist/file_persister.go
+++ b/persist/file_persister.go
@@ -6,7 +6,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
+
+	"github.com/jmartin82/mmock/utils"
+	"github.com/ryanuber/go-glob"
 )
 
 //FilePersister persists body in file
@@ -30,6 +35,31 @@ func (fbp FilePersister) Read(name string) (string, error) {
 	content, err := ioutil.ReadFile(pathToFile)
 	return string(content), err
 }
+
+func (fbp FilePersister) ReadCollection(name string) (string, error) {
+	log.Printf("Reading collection: %s\n", name)
+	filesInCollection := fbp.getCollectionFiles(name)
+
+	contents := []string{}
+	allJSON := true
+
+	sort.Strings(filesInCollection)
+
+	for _, file := range filesInCollection {
+		if fileContent, err := ioutil.ReadFile(file); err == nil {
+			stringContent := string(fileContent)
+			if allJSON {
+				allJSON = utils.IsJSON(stringContent)
+			}
+			contents = append(contents, stringContent)
+		}
+	}
+	if allJSON {
+		return "[" + strings.Join(contents, ",") + "]", nil
+	}
+	return strings.Join(contents, "\n"), nil
+}
+
 func (fbp FilePersister) Write(name, content string) error {
 	pathToFile, fileDir := fbp.getFilePath(name)
 	fileContent := []byte(content)
@@ -39,9 +69,23 @@ func (fbp FilePersister) Write(name, content string) error {
 	}
 	return err
 }
+
 func (fbp FilePersister) Delete(name string) error {
 	pathToFile, _ := fbp.getFilePath(name)
 	return os.Remove(pathToFile)
+}
+
+func (fbp FilePersister) DeleteCollection(name string) error {
+	log.Printf("Deleting collection: %s\n", name)
+	filesInCollection := fbp.getCollectionFiles(name)
+
+	for _, file := range filesInCollection {
+		err := os.Remove(file)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+	return nil
 }
 
 func (fbp FilePersister) getFilePath(fileName string) (pathToFile string, fileDir string) {
@@ -59,6 +103,79 @@ func (fbp FilePersister) getFilePath(fileName string) (pathToFile string, fileDi
 	}
 
 	return pathToFile, fileDir
+}
+
+func (fbp FilePersister) getFolderPath(folderName string) (pathToFolder string) {
+	pathToFolder = path.Join(fbp.PersistPath, folderName)
+
+	var err error
+	pathToFolder, err = filepath.Abs(pathToFolder)
+	if err != nil {
+		return ""
+	}
+	if !strings.HasPrefix(pathToFolder, fbp.PersistPath) {
+		log.Printf("Folder path not under the persist path. FilePath: %s, PersistPath %s", pathToFolder, fbp.PersistPath)
+		return ""
+	}
+
+	return pathToFolder
+}
+
+func (fbp FilePersister) getFilesInCollection(collectionName string) []string {
+	folder := collectionName
+	if strings.Index(folder, "/") == 0 {
+		folder = folder[1:]
+	}
+	filter := ""
+	if i := strings.Index(folder, "/"); i > 0 {
+		filter = folder[(i + 1):]
+		folder = folder[0:i]
+	}
+	fullFolderPath := fbp.getFolderPath(folder)
+
+	filesList := []string{}
+
+	if fullFolderPath == "" {
+		return filesList
+	}
+
+	regex, regexError := regexp.Compile(filter)
+
+	filepath.Walk(fullFolderPath, func(filePath string, fileInfo os.FileInfo, err error) error {
+		if !fileInfo.IsDir() {
+			relativeFilePath := filePath[(len(fullFolderPath) + 1):]
+
+			if (filter == "") || glob.Glob(filter, relativeFilePath) || (regexError == nil && regex.MatchString(relativeFilePath)) {
+				filesList = append(filesList, filePath)
+			}
+		}
+		return nil
+	})
+
+	return filesList
+}
+
+func (fbp FilePersister) getFilesList(name string) []string {
+	if strings.Index(name, ",") == 0 {
+		name = name[1:] // remove the starting comma
+	}
+	fileNames := strings.Split(name, ",")
+	files := []string{}
+	for _, fileName := range fileNames {
+		pathToFile, _ := fbp.getFilePath(fileName)
+		if pathToFile != "" {
+			files = append(files, pathToFile)
+		}
+	}
+	return files
+}
+
+func (fbp FilePersister) getCollectionFiles(name string) []string {
+	if strings.Index(name, ",") > -1 {
+		return fbp.getFilesList(name)
+	}
+
+	return fbp.getFilesInCollection(name)
 }
 
 //NewFilePersister creates a new FilePersister

--- a/persist/file_persister.go
+++ b/persist/file_persister.go
@@ -19,13 +19,13 @@ type FilePersister struct {
 	PersistPath string
 }
 
-func (fbp FilePersister) GetName() string {
+func (fp FilePersister) GetName() string {
 	return "file"
 }
 
-func (fbp FilePersister) Read(name string) (string, error) {
+func (fp FilePersister) Read(name string) (string, error) {
 
-	pathToFile, _ := fbp.getFilePath(name)
+	pathToFile, _ := fp.getFilePath(name)
 	log.Printf("Reading entity: %s\n", pathToFile)
 	if _, err := os.Stat(pathToFile); err != nil {
 		log.Printf("Error reading the entity (%s)\n", err)
@@ -36,9 +36,9 @@ func (fbp FilePersister) Read(name string) (string, error) {
 	return string(content), err
 }
 
-func (fbp FilePersister) ReadCollection(name string) (string, error) {
+func (fp FilePersister) ReadCollection(name string) (string, error) {
 	log.Printf("Reading collection: %s\n", name)
-	filesInCollection := fbp.getCollectionFiles(name)
+	filesInCollection := fp.getCollectionFiles(name)
 
 	contents := []string{}
 	allJSON := true
@@ -60,8 +60,8 @@ func (fbp FilePersister) ReadCollection(name string) (string, error) {
 	return strings.Join(contents, "\n"), nil
 }
 
-func (fbp FilePersister) Write(name, content string) error {
-	pathToFile, fileDir := fbp.getFilePath(name)
+func (fp FilePersister) Write(name, content string) error {
+	pathToFile, fileDir := fp.getFilePath(name)
 	fileContent := []byte(content)
 	err := os.MkdirAll(fileDir, 0755)
 	if err == nil {
@@ -70,14 +70,14 @@ func (fbp FilePersister) Write(name, content string) error {
 	return err
 }
 
-func (fbp FilePersister) Delete(name string) error {
-	pathToFile, _ := fbp.getFilePath(name)
+func (fp FilePersister) Delete(name string) error {
+	pathToFile, _ := fp.getFilePath(name)
 	return os.Remove(pathToFile)
 }
 
-func (fbp FilePersister) DeleteCollection(name string) error {
+func (fp FilePersister) DeleteCollection(name string) error {
 	log.Printf("Deleting collection: %s\n", name)
-	filesInCollection := fbp.getCollectionFiles(name)
+	filesInCollection := fp.getCollectionFiles(name)
 
 	for _, file := range filesInCollection {
 		err := os.Remove(file)
@@ -88,8 +88,8 @@ func (fbp FilePersister) DeleteCollection(name string) error {
 	return nil
 }
 
-func (fbp FilePersister) getFilePath(fileName string) (pathToFile string, fileDir string) {
-	pathToFile = path.Join(fbp.PersistPath, fileName)
+func (fp FilePersister) getFilePath(fileName string) (pathToFile string, fileDir string) {
+	pathToFile = path.Join(fp.PersistPath, fileName)
 	fileDir = path.Dir(pathToFile)
 
 	var err error
@@ -97,31 +97,31 @@ func (fbp FilePersister) getFilePath(fileName string) (pathToFile string, fileDi
 	if err != nil {
 		return "", ""
 	}
-	if !strings.HasPrefix(pathToFile, fbp.PersistPath) {
-		log.Printf("File path not under the persist path. FilePath: %s, PersistPath %s", pathToFile, fbp.PersistPath)
+	if !strings.HasPrefix(pathToFile, fp.PersistPath) {
+		log.Printf("File path not under the persist path. FilePath: %s, PersistPath %s", pathToFile, fp.PersistPath)
 		return "", ""
 	}
 
 	return pathToFile, fileDir
 }
 
-func (fbp FilePersister) getFolderPath(folderName string) (pathToFolder string) {
-	pathToFolder = path.Join(fbp.PersistPath, folderName)
+func (fp FilePersister) getFolderPath(folderName string) (pathToFolder string) {
+	pathToFolder = path.Join(fp.PersistPath, folderName)
 
 	var err error
 	pathToFolder, err = filepath.Abs(pathToFolder)
 	if err != nil {
 		return ""
 	}
-	if !strings.HasPrefix(pathToFolder, fbp.PersistPath) {
-		log.Printf("Folder path not under the persist path. FilePath: %s, PersistPath %s", pathToFolder, fbp.PersistPath)
+	if !strings.HasPrefix(pathToFolder, fp.PersistPath) {
+		log.Printf("Folder path not under the persist path. FilePath: %s, PersistPath %s", pathToFolder, fp.PersistPath)
 		return ""
 	}
 
 	return pathToFolder
 }
 
-func (fbp FilePersister) getFilesInCollection(collectionName string) []string {
+func (fp FilePersister) getFilesInCollection(collectionName string) []string {
 	folder := collectionName
 	if strings.Index(folder, "/") == 0 {
 		folder = folder[1:]
@@ -131,38 +131,38 @@ func (fbp FilePersister) getFilesInCollection(collectionName string) []string {
 		filter = folder[(i + 1):]
 		folder = folder[0:i]
 	}
-	fullFolderPath := fbp.getFolderPath(folder)
+	fullFolderPath := fp.getFolderPath(folder)
 
 	filesList := []string{}
-
 	if fullFolderPath == "" {
-		return filesList
+		return []string{}
 	}
 
 	regex, regexError := regexp.Compile(filter)
 
 	filepath.Walk(fullFolderPath, func(filePath string, fileInfo os.FileInfo, err error) error {
 		if !fileInfo.IsDir() {
-			relativeFilePath := filePath[(len(fullFolderPath) + 1):]
+			if len(filePath) > len(fullFolderPath) {
+				relativeFilePath := filePath[(len(fullFolderPath) + 1):]
 
-			if (filter == "") || glob.Glob(filter, relativeFilePath) || (regexError == nil && regex.MatchString(relativeFilePath)) {
-				filesList = append(filesList, filePath)
+				if (filter == "") || glob.Glob(filter, relativeFilePath) || (regexError == nil && regex.MatchString(relativeFilePath)) {
+					filesList = append(filesList, filePath)
+				}
 			}
 		}
 		return nil
 	})
-
 	return filesList
 }
 
-func (fbp FilePersister) getFilesList(name string) []string {
+func (fp FilePersister) getFilesList(name string) []string {
 	if strings.Index(name, ",") == 0 {
 		name = name[1:] // remove the starting comma
 	}
 	fileNames := strings.Split(name, ",")
 	files := []string{}
 	for _, fileName := range fileNames {
-		pathToFile, _ := fbp.getFilePath(fileName)
+		pathToFile, _ := fp.getFilePath(fileName)
 		if pathToFile != "" {
 			files = append(files, pathToFile)
 		}
@@ -170,12 +170,12 @@ func (fbp FilePersister) getFilesList(name string) []string {
 	return files
 }
 
-func (fbp FilePersister) getCollectionFiles(name string) []string {
+func (fp FilePersister) getCollectionFiles(name string) []string {
 	if strings.Index(name, ",") > -1 {
-		return fbp.getFilesList(name)
+		return fp.getFilesList(name)
 	}
 
-	return fbp.getFilesInCollection(name)
+	return fp.getFilesInCollection(name)
 }
 
 //NewFilePersister creates a new FilePersister

--- a/persist/mongo_persister.go
+++ b/persist/mongo_persister.go
@@ -3,7 +3,12 @@ package persist
 import (
 	"errors"
 	"log"
+	"regexp"
+	"sort"
 	"strings"
+
+	"github.com/jmartin82/mmock/utils"
+	"github.com/ryanuber/go-glob"
 )
 
 var (
@@ -15,7 +20,7 @@ type MongoPersister struct {
 	Repository MongoRepository
 }
 
-func (fbp MongoPersister) GetName() string {
+func (mp MongoPersister) GetName() string {
 	return "mongo"
 }
 
@@ -29,6 +34,32 @@ func (mp MongoPersister) Read(name string) (string, error) {
 
 	content, err := mp.Repository.GetItem(collectionName, id)
 	return content, err
+}
+
+func (mp MongoPersister) ReadCollection(name string) (string, error) {
+	log.Printf("Reading collection: %s\n", name)
+	itemsInCollection := mp.getCollectionItems(name)
+
+	contents := []string{}
+	allJSON := true
+
+	var keys []string
+	for k := range itemsInCollection {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		content := itemsInCollection[key]
+		if allJSON {
+			allJSON = utils.IsJSON(content)
+		}
+		contents = append(contents, content)
+	}
+	if allJSON {
+		return "[" + strings.Join(contents, ",") + "]", nil
+	}
+	return strings.Join(contents, "\n"), nil
 }
 
 func (mp MongoPersister) Write(name, content string) error {
@@ -49,6 +80,20 @@ func (mp MongoPersister) Delete(name string) error {
 	return err
 }
 
+func (mp MongoPersister) DeleteCollection(name string) error {
+	log.Printf("Deleting collection: %s\n", name)
+	itemsInCollection := mp.getCollectionItems(name)
+
+	for key, _ := range itemsInCollection {
+		collectionName, id, err := mp.getItemInfo(key)
+		if err == nil {
+			log.Printf("Deleting entity %s from collection %s\n", id, collectionName)
+			err = mp.Repository.DeleteItem(collectionName, id)
+		}
+	}
+	return nil
+}
+
 func (mp MongoPersister) getItemInfo(name string) (collectionName string, id string, err error) {
 	// remove starting slash
 	if i := strings.Index(name, "/"); i == 0 {
@@ -59,6 +104,66 @@ func (mp MongoPersister) getItemInfo(name string) (collectionName string, id str
 	} else {
 		return "", "", errWrongNameFormat
 	}
+}
+
+func (mp MongoPersister) getItemsInCollection(collectionName string) map[string]string {
+	collection := collectionName
+	if strings.Index(collection, "/") == 0 {
+		collection = collection[1:]
+	}
+	filter := ""
+	if i := strings.Index(collection, "/"); i > 0 {
+		filter = collection[(i + 1):]
+		collection = collection[0:i]
+	}
+	items := map[string]string{}
+
+	if collection == "" {
+		return items
+	}
+
+	regex, regexError := regexp.Compile(filter)
+
+	dataItems, err := mp.Repository.GetAllItems(collection)
+
+	if err != nil {
+		log.Println(err)
+		return items
+	}
+
+	for key, value := range dataItems {
+		if (filter == "") || glob.Glob(filter, key) || (regexError == nil && regex.MatchString(key)) {
+			items[collection+"/"+key] = value
+		}
+	}
+
+	return items
+}
+
+func (mp MongoPersister) getItemsList(name string) map[string]string {
+	if strings.Index(name, ",") == 0 {
+		name = name[1:] // remove the starting comma
+	}
+	keys := strings.Split(name, ",")
+	items := map[string]string{}
+	for _, key := range keys {
+		collection, id, err := mp.getItemInfo(key)
+		if err == nil {
+			value, err := mp.Repository.GetItem(collection, id)
+			if err == nil {
+				items[key] = value
+			}
+		}
+	}
+	return items
+}
+
+func (mp MongoPersister) getCollectionItems(name string) map[string]string {
+	if strings.Index(name, ",") > -1 {
+		return mp.getItemsList(name)
+	}
+
+	return mp.getItemsInCollection(name)
 }
 
 //NewMongoPersister creates a new MongoPersister

--- a/server/dispatcher.go
+++ b/server/dispatcher.go
@@ -59,7 +59,7 @@ func (di *Dispatcher) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		result.Errors = errs
 	}
 
-	log.Printf("Mock match found: %s\n", strconv.FormatBool(result.Found))
+	log.Printf("Mock match found: %s. Name : %s\n", strconv.FormatBool(result.Found), mock.Name)
 
 	if result.Found {
 		if len(mock.Control.ProxyBaseURL) > 0 {

--- a/utils/cartesian.go
+++ b/utils/cartesian.go
@@ -1,0 +1,55 @@
+package utils
+
+// Cartesian gets all combinations of values for keys
+type Cartesian struct {
+}
+
+// GetCombinations returns an array of maps with all combinations built by a map with values
+// "key1": ["1", "2"], "key2":["3", "4"] -> [{"key1":"1", "key2":"3"}, {"key1":"1", "key2":"4"}, {"key1":"2", "key2":"3"}, {"key1":"2", "key2":"4"}]
+func (c Cartesian) GetCombinations(inputMap map[string][]string) []map[string]string {
+	if len(inputMap) == 0 {
+		return []map[string]string{}
+	}
+	inputArray := [][]string{}
+	keys := []string{}
+	for key, value := range inputMap {
+		keys = append(keys, key)
+		inputArray = append(inputArray, value)
+	}
+
+	arrayResult := c.CartesianDistribute(inputArray)
+
+	results := []map[string]string{}
+
+	for _, values := range arrayResult {
+		currentMap := make(map[string]string)
+		for index, value := range values {
+			key := keys[index]
+			currentMap[key] = value
+		}
+		results = append(results, currentMap)
+	}
+
+	return results
+}
+
+// CartesianDistribute getting full combinations distribution using cartesian combination algorithm - http://stackoverflow.com/a/15310051/613113
+func (c Cartesian) CartesianDistribute(input [][]string) [][]string {
+	result := [][]string{}
+
+	c.cartesianHelper(&result, input, []string{}, 0)
+
+	return result
+}
+
+func (c Cartesian) cartesianHelper(output *[][]string, input [][]string, current []string, i int) {
+	max := len(input) - 1
+	for j := 0; j < len(input[i]); j++ {
+		a := append(current, input[i][j])
+		if i == max {
+			*output = append(*output, a)
+		} else {
+			c.cartesianHelper(output, input, a, i+1)
+		}
+	}
+}

--- a/utils/regex_helper.go
+++ b/utils/regex_helper.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+type RegexHelper struct {
+}
+
+func (rh RegexHelper) GetCollectionItems(input string, getRegexParts func(string) (string, string, bool)) ([]string, bool) {
+	matchMap := rh.getMatchMap(input, getRegexParts)
+	if len(matchMap) == 0 {
+		return []string{}, false
+	}
+
+	cartesian := Cartesian{}
+	combinationItems := cartesian.GetCombinations(matchMap)
+
+	results := []string{}
+
+	for _, currentMap := range combinationItems {
+		resultItem := input
+		for key, value := range currentMap {
+			resultItem = strings.Replace(resultItem, key, value, -1)
+		}
+		results = append(results, resultItem)
+	}
+	return results, true
+}
+
+func (rh RegexHelper) getMatchMap(input string, getRegexParts func(string) (string, string, bool)) map[string][]string {
+	regexMap := make(map[string][]string)
+	r := regexp.MustCompile(`\{\{(.+?)\}\}`)
+
+	for _, regexPattern := range r.FindAllString(input, -1) {
+		if _, exists := regexMap[regexPattern]; !exists {
+			regexMap[regexPattern] = []string{regexPattern}
+		}
+	}
+
+	for key, _ := range regexMap {
+		pattern := strings.Trim(key[2:len(key)-2], " ")
+		if regexInput, regexPattern, found := getRegexParts(pattern); found {
+			if calculatedValues, found := rh.getStringParts(regexInput, regexPattern, "value"); found {
+				regexMap[key] = calculatedValues
+			} else {
+				regexMap[key] = []string{key}
+			}
+		} else {
+			regexMap[key] = []string{key}
+		}
+	}
+	return regexMap
+}
+
+func (rh RegexHelper) getStringParts(input string, pattern string, groupName string) ([]string, bool) {
+	r, error := regexp.Compile(pattern)
+	if error != nil {
+		return []string{}, false
+	}
+
+	names := []string{}
+
+	matches := r.FindAllStringSubmatch(input, -1)
+	for _, match := range matches {
+		value, found := rh.getValue(r, match, "value")
+		if found {
+			names = append(names, value)
+		}
+	}
+	return names, len(names) > 0
+}
+
+func (rh RegexHelper) getValue(r *regexp.Regexp, match []string, groupName string) (value string, present bool) {
+	result := make(map[string]string)
+	names := r.SubexpNames()
+	if len(match) >= len(names) {
+		for i, name := range names {
+			if i != 0 {
+				result[name] = match[i]
+			}
+		}
+	}
+
+	value, present = result[groupName]
+
+	return value, present
+}
+
+// GetStringPart gets the value of the group name matching the input using the pattern
+func (rh RegexHelper) GetStringPart(input string, pattern string, groupName string) (string, bool) {
+	r, error := regexp.Compile(pattern)
+	if error != nil {
+		return "", false
+	}
+
+	match := r.FindStringSubmatch(input)
+	result := make(map[string]string)
+	names := r.SubexpNames()
+	if len(match) >= len(names) {
+		for i, name := range names {
+			if i != 0 {
+				result[name] = match[i]
+			}
+		}
+	}
+
+	value, present := result[groupName]
+
+	return value, present
+}

--- a/utils/string_utils.go
+++ b/utils/string_utils.go
@@ -1,8 +1,7 @@
-package parse
+package utils
 
 import (
 	"encoding/json"
-	"regexp"
 
 	"strings"
 
@@ -35,27 +34,17 @@ func JoinJSON(inputs ...string) string {
 	return result.String()
 }
 
-//GetStringPart gets regex mached group value for a given input and regex pattern
-func GetStringPart(input string, pattern string, groupName string) (string, bool) {
-	r, error := regexp.Compile(pattern)
-	if error != nil {
-		return "", false
+//JoinContent returns two contents joined as JSON if both are JSONs otherwise concatenates them
+func JoinContent(value1 string, value2 string) string {
+	if value1 == "" {
+		return value2
+	} else if value2 == "" {
+		return value1
+	} else if (IsJSON(value1)) && IsJSON(value2) {
+		return JoinJSON(value1, value2)
+	} else {
+		return value1 + value2
 	}
-
-	match := r.FindStringSubmatch(input)
-	result := make(map[string]string)
-	names := r.SubexpNames()
-	if len(match) >= len(names) {
-		for i, name := range names {
-			if i != 0 {
-				result[name] = match[i]
-			}
-		}
-	}
-
-	value, present := result[groupName]
-
-	return value, present
 }
 
 //FormatJSON formats a JSON string

--- a/vars/fake_vars.go
+++ b/vars/fake_vars.go
@@ -45,7 +45,7 @@ func (fdp FakeVars) callMethod(name string) (string, bool) {
 	return "", found
 }
 
-func (fdp FakeVars) Fill(m *definition.Mock, input string) string {
+func (fdp FakeVars) Fill(m *definition.Mock, input string, multipleMatch bool) string {
 	r := regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_\.]+)\s*\}\}`)
 
 	return r.ReplaceAllStringFunc(input, func(raw string) string {

--- a/vars/filler.go
+++ b/vars/filler.go
@@ -3,5 +3,5 @@ package vars
 import "github.com/jmartin82/mmock/definition"
 
 type Filler interface {
-	Fill(m *definition.Mock, input string) string
+	Fill(m *definition.Mock, input string, multipleMatch bool) string
 }

--- a/vars/filler_factory.go
+++ b/vars/filler_factory.go
@@ -3,6 +3,7 @@ package vars
 import (
 	"github.com/jmartin82/mmock/definition"
 	"github.com/jmartin82/mmock/persist"
+	"github.com/jmartin82/mmock/utils"
 	"github.com/jmartin82/mmock/vars/fakedata"
 )
 
@@ -15,11 +16,11 @@ type FillerFactory interface {
 type MockFillerFactory struct{}
 
 func (mff MockFillerFactory) CreateRequestFiller(req *definition.Request) Filler {
-	return RequestVars{Request: req}
+	return RequestVars{Request: req, RegexHelper: utils.RegexHelper{}}
 }
 func (mff MockFillerFactory) CreateFakeFiller(fake fakedata.DataFaker) Filler {
 	return FakeVars{Fake: fake}
 }
 func (mff MockFillerFactory) CreatePersistFiller(engines *persist.PersistEngineBag) Filler {
-	return PersistVars{Engines: engines}
+	return PersistVars{Engines: engines, RegexHelper: utils.RegexHelper{}}
 }

--- a/vars/persist_vars.go
+++ b/vars/persist_vars.go
@@ -6,37 +6,100 @@ import (
 
 	"github.com/jmartin82/mmock/definition"
 	"github.com/jmartin82/mmock/persist"
+	"github.com/jmartin82/mmock/utils"
 )
 
 type PersistVars struct {
-	Engines *persist.PersistEngineBag
+	Engines     *persist.PersistEngineBag
+	RegexHelper utils.RegexHelper
 }
 
-func (pp PersistVars) Fill(m *definition.Mock, input string) string {
-	r := regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_\.]+)\s*\}\}`)
-	return r.ReplaceAllStringFunc(input, func(raw string) string {
-		found := false
-		s := ""
-		tag := strings.Trim(raw[2:len(raw)-2], " ")
-		if i := strings.Index(tag, "persist.entity.name"); i == 0 {
-			s = m.Persist.Entity
-			found = true
-		} else if i := strings.Index(tag, "persist.entity.content"); i == 0 {
-			engine := pp.Engines.Get(m.Persist.Engine)
-			content, err := engine.Read(m.Persist.Entity)
-			//if error, we change Response status and body
-			if err != nil {
-				s = ""
-				m.Response.Body = ""
-				m.Response.StatusCode = 404
-			}
-			s = content
-			found = true
-		}
+func (pv PersistVars) Fill(m *definition.Mock, input string, multipleMatch bool) string {
+	r := regexp.MustCompile(`\{\{(.+?)\}\}`)
 
-		if !found {
-			return raw
+	if !multipleMatch {
+		return r.ReplaceAllStringFunc(input, func(raw string) string {
+			// replace the strings
+			if raw, found := pv.replaceString(m, raw); found {
+				return raw
+			}
+			// replace regexes
+			return pv.replaceRegex(m, raw)
+		})
+	} else {
+		// first replace all strings
+		input = r.ReplaceAllStringFunc(input, func(raw string) string {
+			item, _ := pv.replaceString(m, raw)
+			return item
+		})
+		// get multiple entities using regex
+		results, found := pv.RegexHelper.GetCollectionItems(input, func(raw string) (string, string, bool) {
+			return pv.getPersistRegexParts(m, raw)
+		})
+		if found {
+			if len(results) == 1 {
+				return "," + results[0] // add a comma in the beginning so that we will now that the item is a single entity
+			}
+
+			return strings.Join(results, ",")
 		}
-		return s
-	})
+		return input
+	}
+}
+
+func (pv PersistVars) replaceString(m *definition.Mock, raw string) (string, bool) {
+	found := false
+	s := ""
+	tag := strings.Trim(raw[2:len(raw)-2], " ")
+	if tag == "persist.entity.name" {
+		s = m.Persist.Entity
+		found = true
+	} else if i := strings.Index(tag, "persist.collection.name"); i == 0 {
+		s = m.Persist.Collection
+		found = true
+	} else if i := strings.Index(tag, "persist.entity.content"); i == 0 {
+		engine := pv.Engines.Get(m.Persist.Engine)
+		content, err := engine.Read(m.Persist.Entity)
+		//if error, we change Response status and body
+		if err != nil {
+			s = ""
+			m.Response.Body = ""
+			m.Response.StatusCode = 404
+		}
+		s = content
+		found = true
+	} else if i := strings.Index(tag, "persist.collection.content"); i == 0 {
+		engine := pv.Engines.Get(m.Persist.Engine)
+		content, err := engine.ReadCollection(m.Persist.Collection)
+		//if error, we change Response status and body
+		if err != nil {
+			s = ""
+			m.Response.Body = ""
+			m.Response.StatusCode = 404
+		}
+		s = content
+		found = true
+	}
+
+	if !found {
+		return raw, false
+	}
+	return s, true
+}
+
+func (rp PersistVars) getPersistRegexParts(m *definition.Mock, input string) (string, string, bool) {
+	if i := strings.Index(input, "persist.entity.name"); i == 0 && len(input) > len("persist.entity.name") {
+		return m.Persist.Entity, input[20:], true
+	}
+	return "", "", false
+}
+
+func (rp PersistVars) replaceRegex(m *definition.Mock, raw string) string {
+	tag := strings.Trim(raw[2:len(raw)-2], " ")
+	if regexInput, regexPattern, found := rp.getPersistRegexParts(m, tag); found {
+		if result, found := rp.RegexHelper.GetStringPart(regexInput, regexPattern, "value"); found {
+			return result
+		}
+	}
+	return raw
 }

--- a/vars/vars_processor.go
+++ b/vars/vars_processor.go
@@ -13,16 +13,25 @@ type VarsProcessor struct {
 }
 
 func (fp VarsProcessor) Eval(req *definition.Request, m *definition.Mock) {
-	fp.walkAndFill(fp.FillerFactory.CreateRequestFiller(req), m)
-	fp.walkAndFill(fp.FillerFactory.CreateFakeFiller(fp.FakeAdapter), m)
+	requestFiller := fp.FillerFactory.CreateRequestFiller(req)
+	fakeFiller := fp.FillerFactory.CreateFakeFiller(fp.FakeAdapter)
+	persistFiller := fp.FillerFactory.CreatePersistFiller(fp.PersistEngines)
 	entityActions := persist.EntityActions{fp.PersistEngines}
+
+	fp.walkAndFill(requestFiller, m, true)
+	fp.walkAndFill(fakeFiller, m, true)
+
+	// we need to make sure the persisted vars are filled before executing the actions - as we need to make sure the persist vars are replaced in the persist actions
+	fp.walkAndFillPersisted(persistFiller, m)
+
 	entityActions.ApplyActions(m)
-	fp.walkAndFill(fp.FillerFactory.CreatePersistFiller(fp.PersistEngines), m)
+
+	fp.walkAndFill(persistFiller, m, false)
+
 }
 
-func (fp VarsProcessor) walkAndFill(f Filler, m *definition.Mock) {
+func (fp VarsProcessor) walkAndFill(f Filler, m *definition.Mock, fillPersisted bool) {
 	res := &m.Response
-	per := &m.Persist
 	amqp := &m.Notify.Amqp
 	for header, values := range res.Headers {
 		for i, value := range values {
@@ -34,12 +43,20 @@ func (fp VarsProcessor) walkAndFill(f Filler, m *definition.Mock) {
 		res.Cookies[cookie] = f.Fill(m, value, false)
 	}
 
-	res.Body = f.Fill(m, res.Body, false)
 	amqp.Body = f.Fill(m, amqp.Body, false)
+	res.Body = f.Fill(m, res.Body, false)
+
+	if fillPersisted {
+		fp.walkAndFillPersisted(f, m)
+	}
+}
+
+func (fp VarsProcessor) walkAndFillPersisted(f Filler, m *definition.Mock) {
+	per := &m.Persist
+
 	per.Entity = f.Fill(m, per.Entity, false)
 	per.Collection = f.Fill(m, per.Collection, true)
 	for action, value := range per.Actions {
 		per.Actions[action] = f.Fill(m, value, false)
 	}
-
 }

--- a/vars/vars_processor.go
+++ b/vars/vars_processor.go
@@ -26,19 +26,20 @@ func (fp VarsProcessor) walkAndFill(f Filler, m *definition.Mock) {
 	amqp := &m.Notify.Amqp
 	for header, values := range res.Headers {
 		for i, value := range values {
-			res.Headers[header][i] = f.Fill(m, value)
+			res.Headers[header][i] = f.Fill(m, value, false)
 		}
 
 	}
 	for cookie, value := range res.Cookies {
-		res.Cookies[cookie] = f.Fill(m, value)
+		res.Cookies[cookie] = f.Fill(m, value, false)
 	}
 
-	res.Body = f.Fill(m, res.Body)
-	amqp.Body = f.Fill(m, amqp.Body)
-	per.Entity = f.Fill(m, per.Entity)
+	res.Body = f.Fill(m, res.Body, false)
+	amqp.Body = f.Fill(m, amqp.Body, false)
+	per.Entity = f.Fill(m, per.Entity, false)
+	per.Collection = f.Fill(m, per.Collection, true)
 	for action, value := range per.Actions {
-		per.Actions[action] = f.Fill(m, value)
+		per.Actions[action] = f.Fill(m, value, false)
 	}
 
 }


### PR DESCRIPTION
I'm adding some more functionality which I needed when I tried to setup a mock for https://www.pingdom.com/resources/api#MethodGet+Check+List and https://www.pingdom.com/resources/api#MethodDelete+Multiple+Checks. So I've added the "collection" part in the persist item. It may be used by providing collection name for getting/deleting all records in it or by providing a regex matching multiple Ids from either request or body especially for the https://www.pingdom.com/resources/api#MethodDelete+Multiple+Checks. The multiple regex mode is used only in collections and the idea is to match:
```
/delete/users/1,2,3
```
which should delete the users with Ids: 1, 2 and 3 then the persist node should look like:
```
"persist":{  
        "collection":"users/user-{{request.url.(?P<value>\\d+)}}.json"
    }
```
The implementation supports even multiple regex matches by getting full combination between the regex values. You can find the example in the **users-delete-multiple.mixed.json** config file.
In addition to the above I've added support for regex over persist.entity.name, so that if no Id is passed and we generate an Id for the name of the entity, that Id can be reused for persistence in the body. The example is in the **users-post-generate-id.json** config file.
And I have added description to the configuration, so that you can describe what's the purpose of a given configuration for easier reading.
I hope you'll like the changes!