### PR TITLE
added godeps + not logging when the path is not matched

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,91 @@
+{
+	"ImportPath": "github.com/jmartin82/mmock",
+	"GoVersion": "go1.7",
+	"GodepVersion": "v75",
+	"Deps": [
+		{
+			"ImportPath": "github.com/Jeffail/gabs",
+			"Rev": "855034b6b7a3b7144977efcaefe72d2c64b0d039"
+		},
+		{
+			"ImportPath": "github.com/elazarl/go-bindata-assetfs",
+			"Rev": "9a6736ed45b44bf3835afeebb3034b57ed329f3e"
+		},
+		{
+			"ImportPath": "github.com/fsnotify/fsnotify",
+			"Comment": "v1.4.2-2-gfd9ec7d",
+			"Rev": "fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197"
+		},
+		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Rev": "bea76d6a4713e18b7f5321a2b020738552def3ea"
+		},
+		{
+			"ImportPath": "github.com/icrowley/fake",
+			"Rev": "84bff6d01560fb0b5a396ba29534e93fd00d09c6"
+		},
+		{
+			"ImportPath": "github.com/ryanuber/go-glob",
+			"Comment": "v0.1",
+			"Rev": "572520ed46dbddaed19ea3d9541bdd0494163693"
+		},
+		{
+			"ImportPath": "github.com/streadway/amqp",
+			"Rev": "2e25825abdbd7752ff08b270d313b93519a0a232"
+		},
+		{
+			"ImportPath": "github.com/tidwall/gjson",
+			"Rev": "72b0cad1c18345c48d7ddf5ade1f2c45af35b442"
+		},
+		{
+			"ImportPath": "github.com/tidwall/match",
+			"Rev": "173748da739a410c5b0b813b956f89ff94730b4c"
+		},
+		{
+			"ImportPath": "github.com/tidwall/sjson",
+			"Rev": "ed74e8aec806f62f5247b014e5e757576b547ece"
+		},
+		{
+			"ImportPath": "github.com/twinj/uuid",
+			"Comment": "0.10.0-96-g7bbe408",
+			"Rev": "7bbe408d339787c56ec15568c947c0959db1b275"
+		},
+		{
+			"ImportPath": "golang.org/x/net/websocket",
+			"Rev": "40d3034e575b6eafbca34e64224da61de35ae04c"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "b699b7032584f0953262cb2788a0ca19bb494703"
+		},
+		{
+			"ImportPath": "gopkg.in/mgo.v2",
+			"Comment": "r2016.08.01-5-g3f83fa5",
+			"Rev": "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+		},
+		{
+			"ImportPath": "gopkg.in/mgo.v2/bson",
+			"Comment": "r2016.08.01-5-g3f83fa5",
+			"Rev": "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+		},
+		{
+			"ImportPath": "gopkg.in/mgo.v2/internal/json",
+			"Comment": "r2016.08.01-5-g3f83fa5",
+			"Rev": "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+		},
+		{
+			"ImportPath": "gopkg.in/mgo.v2/internal/sasl",
+			"Comment": "r2016.08.01-5-g3f83fa5",
+			"Rev": "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+		},
+		{
+			"ImportPath": "gopkg.in/mgo.v2/internal/scram",
+			"Comment": "r2016.08.01-5-g3f83fa5",
+			"Rev": "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "a5b47d31c556af34a302ce5d659e6fea44d90de0"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/match/mock_match.go
+++ b/match/mock_match.go
@@ -69,12 +69,12 @@ func mockIncludesMethod(mock *definition.Request, method string) bool {
 }
 
 func (mm MockMatch) Match(req *definition.Request, mock *definition.Request) (bool, error) {
-	if !mockIncludesMethod(mock, req.Method) {
-		return false, ErrMethodNotMatch
-	}
-
 	if !glob.Glob(mock.Path, req.Path) {
 		return false, ErrPathNotMatch
+	}
+
+	if !mockIncludesMethod(mock, req.Method) {
+		return false, ErrMethodNotMatch
 	}
 
 	if !mm.matchKeyAndValues(req.QueryStringParameters, mock.QueryStringParameters) {

--- a/route/request_router.go
+++ b/route/request_router.go
@@ -56,8 +56,9 @@ func (rr *RequestRouter) Route(req *definition.Request) (*definition.Mock, map[s
 			return &md, nil
 		}
 		errors[mock.Name] = err.Error()
-		log.Printf("Discarting mock: %s Reason: %s\n", mock.Name, err.Error())
-
+		if err != match.ErrPathNotMatch {
+			log.Printf("Discarding mock: %s Reason: %s\n", mock.Name, err.Error())
+		}
 	}
 
 	return &definition.Mock{Response: definition.Response{StatusCode: 404}}, errors


### PR DESCRIPTION
I've added [Godep](https://github.com/tools/godep) support, so that we can easily find the versions of the packages that work with our code as there might be breaking changes in the next versions of our dependencies.
In addition to that, I've changed a little bit the logging not to write to log when the path is not matched, so that the log won't grow too much when you have many configurations.