### PR TITLE
Adding support for calling endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Mock definition:
 			"userId": "",
 			"appId": "" 
         },
-		"call":[
+		"http":[
 			{
 				"method": "GET|POST|PUT|PATCH|...",
 				"path": "/relative/path/to/call/{{request.url./your/path/(?P<value>\\d+)}}",
@@ -262,7 +262,7 @@ To do a match with queryStringParameters, headers, cookies. All defined keys in 
 	* *userId*: Creating user id - ex: "guest".
 	* *appId*: Creating application id.  
 
-* *call*: An array of [requests](#request) to be made from the mock. This can be useful if you want to create more than one entity when calling an endpoint - that endpoint may call additional endpoints to init other entities related to this one. An example usage can be found in [post-user-orders-call-users.json](config/post-user-orders-call-users.json)
+* *http*: An array of [requests](#request) to be made from the mock. This can be useful if you want to create more than one entity when calling an endpoint - that endpoint may call additional endpoints to init other entities related to this one. An example usage can be found in [post-user-orders-call-users.json](config/post-user-orders-call-users.json)
 
 #### Control (Optional)
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,31 @@ Mock definition:
 			"timestamp": "2016-01-01T00:00:00Z",
 			"userId": "",
 			"appId": "" 
-        }
+        },
+		"call":[
+			{
+				"method": "GET|POST|PUT|PATCH|...",
+				"path": "/relative/path/to/call/{{request.url./your/path/(?P<value>\\d+)}}",
+				"headers": {
+					"name": ["value"]
+				},
+				"cookies": {
+					"name": "value"
+				},
+				"body": "body in request"
+			},
+			{
+				"method": "GET|POST|PUT|PATCH|...",
+				"path": "http://absolute.path/to/call/{{request.url./your/path/(?P<value>\\d+)}}",
+				"headers": {
+					"name": ["value"]
+				},
+				"cookies": {
+					"name": "value"
+				},
+				"body": "body in request"
+			},
+		]
 	}
 	"control": {
 		"proxyBaseURL": "string (original URL endpoint)
@@ -236,7 +260,9 @@ To do a match with queryStringParameters, headers, cookies. All defined keys in 
 	* *timestamp*: Message timestamp.
 	* *type*: Message type name.
 	* *userId*: Creating user id - ex: "guest".
-	* *appId*: Creating application id.
+	* *appId*: Creating application id.  
+
+* *call*: An array of [requests](#request) to be made from the mock. This can be useful if you want to create more than one entity when calling an endpoint - that endpoint may call additional endpoints to init other entities related to this one. An example usage can be found in [post-user-orders-call-users.json](config/post-user-orders-call-users.json)
 
 #### Control (Optional)
 
@@ -346,7 +372,7 @@ You can check the sample configurations for persistence in the following files:
 That configurations are going to work either with [File system](#file-system) or [MongoDB](#mongodb) modes.
 
 ### Contributors
-- [@vtrifonov](https://github.com/vtrifonov) [Persistence](#persist-optional) feature, improved variables support and [AMQP](#notify-optional) sending
+- [@vtrifonov](https://github.com/vtrifonov) [Persistence](#persist-optional) and [Notification](#notify-optional) features and improved variables support
 
 ### Contributing
 

--- a/config/post-user-orders-call-users.json
+++ b/config/post-user-orders-call-users.json
@@ -21,7 +21,7 @@
         "body":"{{persist.entity.content}}"
     },
     "notify":{  
-        "call":[{  
+        "http":[{  
             "method":"POST",
             "path":"/users/{{request.url./user-orders/(?P<value>\\d+)}}.json",
             "body":"{ \"FirstName\": \"{{fake.FirstName}}\", \"LastName\": \"{{fake.LastName}}\" }"

--- a/config/post-user-orders-call-users.json
+++ b/config/post-user-orders-call-users.json
@@ -1,0 +1,30 @@
+{  
+    "description": "Sends a message to an AMQP server after the content is persisted",
+    "request":{  
+        "method":"POST",
+        "path":"/user-orders/*.json"
+    },
+    "persist": {
+        "entity": "/orders/user-orders-{{request.url./user-orders/(?P<value>\\d+)}}.json",
+        "actions" : {
+            "write" : "{{request.body}}",
+            "append" : "{ \"user_id\": {{request.url./user-orders/(?P<value>\\d+)}}, \"order\": \"{{ fake.Digits }}\" }"
+        }
+    },
+    "response":{  
+        "statusCode":202,
+        "headers":{  
+            "Content-Type":[  
+            "application/json"
+            ]
+        },
+        "body":"{{persist.entity.content}}"
+    },
+    "notify":{  
+        "call":[{  
+            "method":"POST",
+            "path":"/users/{{request.url./user-orders/(?P<value>\\d+)}}.json",
+            "body":"{ \"FirstName\": \"{{fake.FirstName}}\", \"LastName\": \"{{fake.LastName}}\" }"
+        }]
+    }
+}

--- a/definition/mock.go
+++ b/definition/mock.go
@@ -8,6 +8,7 @@ type Control struct {
 }
 
 type Actions map[string]string
+type Requests []Request
 
 type Persist struct {
 	Entity     string  `json:"entity"`
@@ -18,6 +19,7 @@ type Persist struct {
 
 type Notify struct {
 	Amqp AMQPPublishing `json:"amqp"`
+	Call Requests       `json:"call"`
 }
 
 //Mock contains the user mock definition

--- a/definition/mock.go
+++ b/definition/mock.go
@@ -19,7 +19,7 @@ type Persist struct {
 
 type Notify struct {
 	Amqp AMQPPublishing `json:"amqp"`
-	Call Requests       `json:"call"`
+	Http Requests       `json:"http"`
 }
 
 //Mock contains the user mock definition

--- a/notify/caller.go
+++ b/notify/caller.go
@@ -1,0 +1,9 @@
+package notify
+
+import "github.com/jmartin82/mmock/definition"
+
+//Caller makes remote http requests
+type Caller interface {
+	//Call makes a remote http request
+	Call(m definition.Request) bool
+}

--- a/notify/mock_notifier.go
+++ b/notify/mock_notifier.go
@@ -21,7 +21,7 @@ func NewMockNotifier() MockNotifier {
 //Notify the needed parties
 func (notifier MockNotifier) Notify(mock *definition.Mock) bool {
 	success := notifier.Sender.Send(mock)
-	for _, request := range mock.Notify.Call {
+	for _, request := range mock.Notify.Http {
 		successfulRequest := notifier.Caller.Call(request)
 		success = success && successfulRequest
 	}

--- a/notify/mock_notifier.go
+++ b/notify/mock_notifier.go
@@ -1,0 +1,29 @@
+package notify
+
+import (
+	"github.com/jmartin82/mmock/amqp"
+	"github.com/jmartin82/mmock/definition"
+)
+
+//MockNotifier notifies the needed parties
+type MockNotifier struct {
+	Sender amqp.Sender
+	Caller Caller
+}
+
+func NewMockNotifier() MockNotifier {
+	return MockNotifier{
+		Sender: amqp.MessageSender{},
+		Caller: RequestCaller{},
+	}
+}
+
+//Notify the needed parties
+func (notifier MockNotifier) Notify(mock *definition.Mock) bool {
+	success := notifier.Sender.Send(mock)
+	for _, request := range mock.Notify.Call {
+		successfulRequest := notifier.Caller.Call(request)
+		success = success && successfulRequest
+	}
+	return success
+}

--- a/notify/notifier.go
+++ b/notify/notifier.go
@@ -1,0 +1,9 @@
+package notify
+
+import "github.com/jmartin82/mmock/definition"
+
+//Notifier notifies the needed parties
+type Notifier interface {
+	//Notify the needed parties
+	Notify(m *definition.Mock) bool
+}

--- a/notify/request_caller.go
+++ b/notify/request_caller.go
@@ -1,0 +1,62 @@
+package notify
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jmartin82/mmock/definition"
+	"github.com/jmartin82/mmock/utils"
+)
+
+//RequestCaller makes remote http requests
+type RequestCaller struct {
+}
+
+//Call makes a remote http request
+func (caller RequestCaller) Call(request definition.Request) bool {
+
+	requestURL, err := url.Parse(request.Path)
+	if err != nil {
+		log.Printf("Invalid url(%s) passed: %s", request.Path, err)
+		return false
+	}
+
+	if !requestURL.IsAbs() {
+		request.Path = utils.GetServerAddress() + "/" + strings.TrimPrefix(request.Path, "/")
+	}
+
+	req, err := http.NewRequest(request.Method, request.Path, bytes.NewBufferString(request.Body))
+	if err != nil {
+		log.Printf("Error creating http request: %s", err)
+		return false
+	}
+
+	for header, values := range request.Headers {
+		for _, value := range values {
+			req.Header.Add(header, value)
+		}
+	}
+
+	cookies := []string{}
+	for cookie, value := range request.Cookies {
+		cookies = append(cookies, fmt.Sprintf("%s=%s", cookie, value))
+		req.Header.Add("Set-Cookie", strings.Join(cookies, ";"))
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	defer resp.Body.Close()
+	if err != nil {
+		log.Printf("Error executing request to %s. Error: %s", request.Path, err)
+		return false
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	log.Printf("Request to %s returned status code %d and body: %s", request.Path, resp.StatusCode, body)
+	return true
+}

--- a/server/dispatcher.go
+++ b/server/dispatcher.go
@@ -8,8 +8,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jmartin82/mmock/amqp"
+	"reflect"
+
 	"github.com/jmartin82/mmock/definition"
+	"github.com/jmartin82/mmock/notify"
 	"github.com/jmartin82/mmock/proxy"
 	"github.com/jmartin82/mmock/route"
 	"github.com/jmartin82/mmock/translate"
@@ -23,7 +25,7 @@ type Dispatcher struct {
 	Router        route.Router
 	Translator    translate.MessageTranslator
 	VarsProcessor vars.VarsProcessor
-	MessageSender amqp.Sender
+	Notifier      notify.Notifier
 	Mlog          chan definition.Match
 }
 
@@ -69,8 +71,8 @@ func (di *Dispatcher) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 			di.VarsProcessor.Eval(&mRequest, mock)
 
-			if (definition.Notify{}) != mock.Notify {
-				go di.MessageSender.Send(mock)
+			if !reflect.DeepEqual(definition.Notify{}, mock.Notify) {
+				go di.Notifier.Notify(mock)
 			}
 
 			if mock.Control.Crazy {

--- a/utils/static_variables.go
+++ b/utils/static_variables.go
@@ -1,0 +1,18 @@
+package utils
+
+// Variables is used for storing static variables
+type StaticVariables struct {
+	ServerAddress string
+}
+
+var variables = StaticVariables{}
+
+// SetServerAddress sets ServerAddress variable
+func SetServerAddress(address string) {
+	variables.ServerAddress = address
+}
+
+// GetServerAddress returns ServerAddress variable
+func GetServerAddress() string {
+	return variables.ServerAddress
+}

--- a/vars/vars_processor.go
+++ b/vars/vars_processor.go
@@ -34,7 +34,6 @@ func (fp VarsProcessor) Eval(req *definition.Request, m *definition.Mock) {
 
 func (fp VarsProcessor) walkAndFill(f Filler, m *definition.Mock, fillPersisted bool) {
 	res := &m.Response
-	amqp := &m.Notify.Amqp
 	for header, values := range res.Headers {
 		for i, value := range values {
 			res.Headers[header][i] = f.Fill(m, value, false)
@@ -45,11 +44,33 @@ func (fp VarsProcessor) walkAndFill(f Filler, m *definition.Mock, fillPersisted 
 		res.Cookies[cookie] = f.Fill(m, value, false)
 	}
 
-	amqp.Body = f.Fill(m, amqp.Body, false)
 	res.Body = f.Fill(m, res.Body, false)
+
+	fp.walkAndFillNotify(f, m)
 
 	if fillPersisted {
 		fp.walkAndFillPersisted(f, m)
+	}
+}
+
+func (fp VarsProcessor) walkAndFillNotify(f Filler, m *definition.Mock) {
+	amqp := &m.Notify.Amqp
+	amqp.Body = f.Fill(m, amqp.Body, false)
+
+	call := m.Notify.Call
+
+	for index, request := range call {
+		m.Notify.Call[index].Body = f.Fill(m, request.Body, false)
+		m.Notify.Call[index].Path = f.Fill(m, request.Path, false)
+		for header, values := range request.Headers {
+			for i, value := range values {
+				m.Notify.Call[index].Headers[header][i] = f.Fill(m, value, false)
+			}
+		}
+
+		for cookie, value := range request.Cookies {
+			m.Notify.Call[index].Cookies[cookie] = f.Fill(m, value, false)
+		}
 	}
 }
 

--- a/vars/vars_processor.go
+++ b/vars/vars_processor.go
@@ -57,19 +57,19 @@ func (fp VarsProcessor) walkAndFillNotify(f Filler, m *definition.Mock) {
 	amqp := &m.Notify.Amqp
 	amqp.Body = f.Fill(m, amqp.Body, false)
 
-	call := m.Notify.Call
+	http := m.Notify.Http
 
-	for index, request := range call {
-		m.Notify.Call[index].Body = f.Fill(m, request.Body, false)
-		m.Notify.Call[index].Path = f.Fill(m, request.Path, false)
+	for index, request := range http {
+		m.Notify.Http[index].Body = f.Fill(m, request.Body, false)
+		m.Notify.Http[index].Path = f.Fill(m, request.Path, false)
 		for header, values := range request.Headers {
 			for i, value := range values {
-				m.Notify.Call[index].Headers[header][i] = f.Fill(m, value, false)
+				m.Notify.Http[index].Headers[header][i] = f.Fill(m, value, false)
 			}
 		}
 
 		for cookie, value := range request.Cookies {
-			m.Notify.Call[index].Cookies[cookie] = f.Fill(m, value, false)
+			m.Notify.Http[index].Cookies[cookie] = f.Fill(m, value, false)
 		}
 	}
 }


### PR DESCRIPTION
The idea here is to support calling endpoints as a part of the processing. I need this in order to create more than one entity with a single request. To achieve this I'm making request to another endpoint in the mock after storing the main entity. You can check this configuration **post-user-orders-call-users.json**. However I think that this functionality can be useful for many other cases.