### PR TITLE
Use Watcher's AddRecursive method

### DIFF
--- a/definition/file_definition.go
+++ b/definition/file_definition.go
@@ -98,8 +98,8 @@ func (fd *FileDefinition) WatchDir() {
 		}
 	}()
 
-	// Watch test_folder recursively for changes.
-	if err := fd.watcher.Add(fd.Path); err != nil {
+	// Watch dir recursively for changes.
+	if err := fd.watcher.AddRecursive(fd.Path); err != nil {
 		log.Println("Impossible bind the config folder to the files monitor: ", err)
 		return
 	}


### PR DESCRIPTION
This commit updates the `WatchDir` method to use `Watcher`'s new API, replacing `Add` with `AddRecursive` since the `Add` method is no longer recursive by default.