### PR TITLE
Feature/body parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built with Go - Mmock runs without installation on multiple platforms.
 
 Mock definition file example:
 
-```
+```json
 {
 	"request": {
 		"method": "GET",
@@ -60,7 +60,7 @@ Mock definition file example:
 Or
 
 
-```
+```yaml
 ---
 request:
   method: GET
@@ -120,7 +120,7 @@ To configure Mmock, use command line flags described in help.
 
 Mock definition:
 
-```
+```json
 {
 	"description": "Some text that describes the intended usage of the current configuration",
 	"request": {
@@ -152,12 +152,12 @@ Mock definition:
 	"control": {
 		"scenario": {
 			"name": "string (scenario name)",
-            "requiredState": [
+			"requiredState": [
 				"not_started (default state)",
-                "another_state_name"
-            ],
-            "newState": "new_stat_neme"
-        },
+				"another_state_name"
+			],
+			"newState": "new_stat_neme"
+		},
 		"proxyBaseURL": "string (original URL endpoint)",
 		"delay": "int (response delay in seconds)",
 		"crazy": "bool (return random 5xx)",
@@ -259,7 +259,7 @@ This makes it possible to verify that a request matching a specific pattern was 
 **Data Params**:  <br>
 Like stubbing this call also uses the same DSL to filter and query requests.
 
-```
+```json
 {
 	"host": "example.com",
 	"method": "GET|POST|PUT|PATCH|... (Mandatory)", 
@@ -327,7 +327,7 @@ Also there is a real time endpoint available through WebSockets that broadcast a
 
 All enpoints have the same output format:
 
-```
+```json
 [
   {
     "time": 1486563983,
@@ -372,7 +372,8 @@ Request data:
  - request.cookie."*key*"
  - request.url
  - request.body
-
+ - request.body."*key*" (both `application/json` and `application/x-www-form-urlencoded requests)
+ - request.body."*deep*"."*key*" (only for `application/json` requests)
 
 [Fake](https://godoc.org/github.com/icrowley/fake) data:
 

--- a/config/body-form.json
+++ b/config/body-form.json
@@ -1,0 +1,11 @@
+{
+	"description": "Returns body parameters when send as form-data values",
+	"request": {
+		"method": "POST",
+		"path": "/body/form"
+	},
+	"response": {
+		"statusCode": 200,
+		"body": "User with email {{request.body.email}} as been tracked with uuid {{request.body.tracking[uuid]}}"
+	}
+}

--- a/config/body-json.yaml
+++ b/config/body-json.yaml
@@ -1,0 +1,23 @@
+request: 
+  method: POST
+  path: /body/json
+response:
+  statusCode: 200
+  headers:
+    Content-Type: 
+      - "application/json"
+  body: >
+    {  
+      "id": {{fake.Digits}},
+      "email": "{{request.body.email}}",
+      "age": {{request.body.age}},
+      "height": {{request.body.height}},
+      "weight": {{request.body.weight}},
+      "active": {{request.body.active}},
+      "level": {{request.body.level}},
+      "friends": {{request.body.friends}},
+      "attributes": {{request.body.attributes}},
+      "tracking": {
+        "uuid": "{{request.body.tracking.uuid}}"
+      }
+    }

--- a/config/body-json.yaml
+++ b/config/body-json.yaml
@@ -18,6 +18,9 @@ response:
       "friends": {{request.body.friends}},
       "attributes": {{request.body.attributes}},
       "tracking": {
-        "uuid": "{{request.body.tracking.uuid}}"
+        "uuid": "{{request.body.tracking.uuid}}",
+        "deeper": {
+          "level": "{{request.body.tracking.nesting.level}}"
+        }
       }
     }

--- a/vars/processor_test.go
+++ b/vars/processor_test.go
@@ -324,3 +324,21 @@ func TestReplaceMissingTags(t *testing.T) {
 		t.Error("Replaced missing tags not match", mock.Response.Body)
 	}
 }
+
+func TestReplaceBodyFormUrlEncodedTags(t *testing.T) {
+	req := definition.Request{}
+	req.Body = "one=foo&two[array]=bar"
+	req.Headers = make(definition.Values)
+	req.Headers["Content-Type"] = []string{"application/x-www-form-urlencoded"}
+
+	res := definition.Response{}
+	res.Body = "Form data placeholders. One '{{request.body.one}}'. Two '{{request.body.two[array]}}'."
+
+	mock := definition.Mock{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != "Form data placeholders. One 'foo'. Two 'bar'." {
+		t.Error("Replaced tags from body form do not match", mock.Response.Body)
+	}
+}

--- a/vars/request.go
+++ b/vars/request.go
@@ -5,6 +5,7 @@ import (
 
 	urlmatcher "github.com/azer/url-router"
 	"github.com/jmartin82/mmock/definition"
+	"net/url"
 )
 
 type Request struct {
@@ -21,6 +22,8 @@ func (rp Request) Fill(holders []string) map[string]string {
 		if tag == "request.body" && rp.Request.Body != "" {
 			s = rp.Request.Body
 			found = true
+		} else if i := strings.Index(tag, "request.body."); i == 0 {
+			s, found = rp.getBodyParam(rp.Request, tag[13:])
 		} else if i := strings.Index(tag, "request.query."); i == 0 {
 			s, found = rp.getQueryStringParam(rp.Request, tag[14:])
 		} else if i := strings.Index(tag, "request.path."); i == 0 {
@@ -44,6 +47,21 @@ func (rp Request) getPathParm(m *definition.Mock, req *definition.Request, name 
 
 	value, f := mparm.Params[name]
 	if !f {
+		return "", false
+	}
+
+	return value, true
+}
+
+func (rp Request) getBodyParam(req *definition.Request, name string) (string, bool) {
+
+	values, err := url.ParseQuery(req.Body)
+	if err != nil {
+		return "", false
+	}
+
+	value := values.Get(name)
+	if value == "" {
 		return "", false
 	}
 

--- a/vars/request.go
+++ b/vars/request.go
@@ -148,7 +148,7 @@ func (rp Request) getJsonObjectParamRecursive(payload map[string]*json.RawMessag
 }
 
 func (rp Request) getJsonValue(value *json.RawMessage) (string, bool) {
-	// Is json 'null' value
+
 	if value == nil {
 		return "null", true
 	}

--- a/vars/request.go
+++ b/vars/request.go
@@ -29,7 +29,7 @@ func (rp Request) Fill(holders []string) map[string]string {
 		} else if i := strings.Index(tag, "request.query."); i == 0 {
 			s, found = rp.getQueryStringParam(rp.Request, tag[14:])
 		} else if i := strings.Index(tag, "request.path."); i == 0 {
-			s, found = rp.getPathParm(rp.Mock, rp.Request, tag[13:])
+			s, found = rp.getPathParam(rp.Mock, rp.Request, tag[13:])
 		} else if i := strings.Index(tag, "request.cookie."); i == 0 {
 			s, found = rp.getCookieParam(rp.Request, tag[15:])
 		}
@@ -42,7 +42,7 @@ func (rp Request) Fill(holders []string) map[string]string {
 	return vars
 }
 
-func (rp Request) getPathParm(m *definition.Mock, req *definition.Request, name string) (string, bool) {
+func (rp Request) getPathParam(m *definition.Mock, req *definition.Request, name string) (string, bool) {
 
 	routes := urlmatcher.New(m.Request.Path)
 	mparm := routes.Match(req.Path)


### PR DESCRIPTION
Hi dear J. Martin, I would like to submit a feature to parse the body of the requests to replace placeholders in the response

I've added two examples in the config

Requests used for testing:
* **JSON body parsing**
```
POST /body/json HTTP/1.1
Content-Type: application/json
```
```json
{
	"email": "hilari@hilarimoragrega.com",
	"age": 34,
	"height": 5.66,
	"weight": null,
	"level": -8,
	"active": true,
	"friends": [
		"jordi.martin@gmail.com", 
		"alfons.faubert@gmail.com"
	],
	"attributes": {
		"programming": 15,
		"trolling": 27
	},
	"tracking": {
		"uuid":"0bd74115-2307-458f-8288-b726724045ef",
		"nesting": {
			"level": "nesting is ok"
		},
		"discarded": "do not return"
	}
}
```
* **Form body parsing**
```
POST /body/form HTTP/1.1
Content-Type: application/x-www-form-urlencoded; charset=utf-8

email=hilari%40hilarimoragrega.com&tracking%5Buuid%5D=0bd74115-2307-458f-8288-b726724045ef%0A%0A
```