### PR TITLE
Bind the config to react to config changes on start

### DIFF
--- a/definition/mapping.go
+++ b/definition/mapping.go
@@ -46,6 +46,7 @@ type ConfigMapping struct {
 func NewConfigMapping(path string, mapper *ConfigMapper, fsUpdate chan struct{}) *ConfigMapping {
 	cm := &ConfigMapping{path: path, mapper: mapper, mapping: make(map[string]Mock), fsUpdate: fsUpdate}
 	cm.populate()
+	cm.fsBind()
 	go cm.listenFsChanges()
 	return cm
 }


### PR DESCRIPTION
On start, _mmock_ is listening to changes in the config, but it isn't bind, therefore the config is not updated. Only the first call to the config API triggers the binding