### PR TITLE
Allowing returning body parts in the response

### DIFF
--- a/vars/processor_test.go
+++ b/vars/processor_test.go
@@ -324,3 +324,35 @@ func TestReplaceMissingTags(t *testing.T) {
 		t.Error("Replaced missing tags not match", mock.Response.Body)
 	}
 }
+
+func TestReplaceExistingBodyTag(t *testing.T) {
+	req := definition.Request{}
+	req.Body = "{\"persons\":{\"bodies\":[{\"body\":\"is my body\"}, {\"body\":\"is your body\"}]}}"
+
+	res := definition.Response{}
+	res.Body = "Request Body {{request.body.persons.bodies.1.body}}"
+
+	mock := definition.Mock{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != "Request Body \"is your body\"" {
+		t.Error("Replaced missing tags not match", mock.Response.Body)
+	}
+}
+
+func TestReplaceUnExistingBodyTag(t *testing.T) {
+	req := definition.Request{}
+	req.Body = "{\"persons\":{\"bodies\":[{\"body\":\"is my body\"}, {\"body\":\"is your body\"}]}}"
+
+	res := definition.Response{}
+	res.Body = "Request Body {{request.body.whatever}}"
+
+	mock := definition.Mock{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != "Request Body {{request.body.whatever}}" {
+		t.Error("Unexisting tags in body match", mock.Response.Body)
+	}
+}

--- a/vars/request.go
+++ b/vars/request.go
@@ -101,5 +101,9 @@ func (rp Request) getFromBodyByPath(path string) (string, bool) {
 		}
 	}
 
-	return jsonParsed.String(), true
+	if jsonParsed.Exists() {
+		return jsonParsed.String(), true
+	}
+
+	return "", false
 }


### PR DESCRIPTION
Hello! I write in english since this is public and maybe not everyone using the library knows catalan nor spanish.

I think Miguel already talked to you about me opening a Pull request, here are details:

I added a function in the vars filler in order to be able to return parts of the body in the return, in order to do that I used a json parse library called gabs, I also had to add array support by array index since gabs allows to do operations in arrays but not in the way I wanted.

In order to use the feature I have used the same place holder you are using for the body {{request.body}} but after "body" you can define any path you want to navigate through the body parts of the request.

So, imagine the body request is as follows:
```json
{
    "car" :  { 
        "doors": [
            {"name": "front door", "color": "red"}, 
            {"name": "front door", "color": "blue"}
        ]
    }
}
```

If in the response config you write: The color of the door is: {{request.body.car.doors.1.color}}
it would return: The color of the door is "blue"

If in the response config you write: {"colors": {{request.body.car.doors.color}}}
it would return: {"colors": ["red", "blue"]}  (this is default gabs array access)

If in the response config you write: {"doors": {{request.body.car.doors}}}
it would return: {"doors": [{"name": "front door", "color": "red"}, {"name": "front door", "color":"blue"}]}

If in the response config you write: {"nonexistent": {{request.body.whatever}}}
it would return: {"nonexistent": {{request.body.whatever}}}

I think it's quite straight forward, feel free to comment/edit/close this PR, I have not developed much in go so be kind, hehe. Any advise would be more than welcomed! :D
