### PR TITLE
FEATURE: Implements access to array indexes in dynamic response

### DIFF
--- a/vars/processor_test.go
+++ b/vars/processor_test.go
@@ -382,6 +382,8 @@ func TestReplaceJsonBodyEncodedTags(t *testing.T) {
   "active": {{request.body.active}},
   "level": {{request.body.level}},
   "friends": {{request.body.friends}},
+  "first-friend": "{{request.body.friends.0}}",
+  "last-friend": "{{request.body.friends.1}}",
   "attributes": {{request.body.attributes}},
   "tracking": {
     "uuid": "{{request.body.tracking.uuid}}",
@@ -400,14 +402,10 @@ func TestReplaceJsonBodyEncodedTags(t *testing.T) {
   "weight": null,
   "active": true,
   "level": -8,
-  "friends": [
-    "jordi.martin@gmail.com", 
-    "alfons.faubert@gmail.com"
-  ],
-  "attributes": {
-    "programming": 15,
-    "trolling": 27
-  },
+  "friends": ["jordi.martin@gmail.com","alfons.faubert@gmail.com"],
+  "first-friend": "jordi.martin@gmail.com",
+  "last-friend": "alfons.faubert@gmail.com",
+  "attributes": {"programming":15,"trolling":27},
   "tracking": {
     "uuid": "0bd74115-2307-458f-8288-b726724045ef",
     "deeper": {

--- a/vars/request.go
+++ b/vars/request.go
@@ -135,7 +135,7 @@ func (rp Request) getJsonBodyParam(req *definition.Request, name string) (string
 		if arrayMapper, ok := payload.([]interface{}); ok {
 			index, err := strconv.Atoi(value)
 
-			if err != nil {
+			if err != nil || index >= len(arrayMapper) {
 				return "", false
 			}
 


### PR DESCRIPTION
This PR implements the possibility of access to an array index in dynamic responses.
Til now you could have access to entire objects and currently you can access to specific key inside an array in case you have.

So like could be seen in the updated test, you could specify a dynamic response with a key like this:

`{{request.body.friends.0}}`

Even if the it's a composite array, you could access to a property of it in this way:

`{{request.body.friends.0.some_property_which_you_wanna_get}}`



- In the case that you would have a property called `0`which it's not an index part of array the behavior continues being the same.
- In the supposed case that specifies a undefined index the behavior is the same that accessing to non-declarated property.