### PR TITLE
Add scenario set and pause state endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,9 +312,24 @@ Like stubbing this call also uses the same DSL to filter and query requests.
 
 ### Scenario
 
-**Title** : Clean all scenarios status.<br>
+**Title** : Clean all scenarios status and pause state.<br>
 **URL** : /api/scenarios/reset_all<br>
 **Method** : GET<br>
+**Response Codes**: Success (200 OK)<br>
+
+**Title** : Manually progress a scenario state machine to the given state.<br>
+**URL** : /api/scenarios/set/:scenario/:state<br>
+**Method** : PUT<br>
+**Response Codes**: Success (200 OK)<br>
+
+**Title** : Pause prevents all scenarios state machines from progressing to a new state.<br>
+**URL** : /api/scenarios/pause<br>
+**Method** : PUT<br>
+**Response Codes**: Success (200 OK)<br>
+
+**Title** : Allow scenarios state machines to continue.<br>
+**URL** : /api/scenarios/unpause<br>
+**Method** : PUT<br>
 **Response Codes**: Success (200 OK)<br>
 
 ### Mapping

--- a/console/dispatcher.go
+++ b/console/dispatcher.go
@@ -73,6 +73,9 @@ func (di *Dispatcher) Start() {
 	e.GET("/api/request/matched", di.requestMatchedHandler)
 	e.GET("/api/request/unmatched", di.requestUnMatchedHandler)
 	e.GET("/api/scenarios/reset_all", di.scenariosResetHandler)
+	e.PUT("/api/scenarios/set/:scenario/:state", di.scenariosSetHandler)
+	e.PUT("/api/scenarios/pause", di.scenariosPauseHandler)
+	e.PUT("/api/scenarios/unpause", di.scenariosUnpauseHandler)
 
 	//mapping
 	e.GET("/api/mapping", di.mappingListHandler)
@@ -246,6 +249,30 @@ func (di *Dispatcher) scenariosResetHandler(c echo.Context) error {
 	di.Scenario.ResetAll()
 	ar := &ActionResponse{
 		Result: "reset",
+	}
+	return c.JSON(http.StatusOK, ar)
+}
+
+func (di *Dispatcher) scenariosSetHandler(c echo.Context) error {
+	di.Scenario.SetState(c.Param("scenario"), c.Param("state"))
+	ar := &ActionResponse{
+		Result: "updated",
+	}
+	return c.JSON(http.StatusOK, ar)
+}
+
+func (di *Dispatcher) scenariosPauseHandler(c echo.Context) error {
+	di.Scenario.SetPaused(true)
+	ar := &ActionResponse{
+		Result: "updated",
+	}
+	return c.JSON(http.StatusOK, ar)
+}
+
+func (di *Dispatcher) scenariosUnpauseHandler(c echo.Context) error {
+	di.Scenario.SetPaused(false)
+	ar := &ActionResponse{
+		Result: "updated",
 	}
 	return c.JSON(http.StatusOK, ar)
 }

--- a/match/spy_test.go
+++ b/match/spy_test.go
@@ -22,6 +22,13 @@ func (dsm DummyScenarioManager) GetState(name string) string {
 	return ""
 }
 
+func (dsm DummyScenarioManager) GetPaused() bool {
+	return false
+}
+
+func (dsm DummyScenarioManager) SetPaused(_ bool) {
+}
+
 func TestFindMatches(t *testing.T) {
 	spy := NewSpy(NewTester(DummyScenarioManager{}), NewMemoryStore())
 

--- a/scenario/director.go
+++ b/scenario/director.go
@@ -5,4 +5,6 @@ type Director interface {
 	GetState(name string) string
 	Reset(name string) bool
 	ResetAll()
+	SetPaused(newstate bool)
+	GetPaused() bool
 }

--- a/scenario/memory_store.go
+++ b/scenario/memory_store.go
@@ -11,6 +11,7 @@ func NewMemoryStore() *MemoryStore {
 
 type MemoryStore struct {
 	status map[string]string
+	paused bool
 }
 
 func (sm *MemoryStore) Reset(name string) bool {
@@ -23,9 +24,13 @@ func (sm *MemoryStore) Reset(name string) bool {
 
 func (sm *MemoryStore) ResetAll() {
 	sm.status = make(map[string]string)
+	sm.paused = false
 }
 
 func (sm *MemoryStore) SetState(name, status string) {
+	if sm.paused {
+		return
+	}
 	sm.status[strings.ToLower(name)] = strings.ToLower(status)
 }
 
@@ -34,4 +39,12 @@ func (sm *MemoryStore) GetState(name string) string {
 		return v
 	}
 	return "not_started"
+}
+
+func (sm *MemoryStore) GetPaused() bool {
+	return sm.paused
+}
+
+func (sm *MemoryStore) SetPaused(newstate bool) {
+	sm.paused = newstate
 }

--- a/scenario/memory_store_test.go
+++ b/scenario/memory_store_test.go
@@ -2,7 +2,7 @@ package scenario
 
 import "testing"
 
-func TestBasicSenarioManage(t *testing.T) {
+func TestBasicScenarioManage(t *testing.T) {
 	ms := NewMemoryStore()
 
 	state := ms.GetState("scene1")
@@ -31,6 +31,22 @@ func TestBasicSenarioManage(t *testing.T) {
 	ms.ResetAll()
 	if ms.GetState("Scene1") != "not_started" || ms.GetState("Scene2") != "not_started" {
 		t.Errorf("Invalid initial state")
+	}
+
+}
+
+func TestScenarioManagePause(t *testing.T) {
+	ms := NewMemoryStore()
+	ms.SetPaused(true)
+
+	ms.SetState("Scene1", "some_state")
+	if ms.GetState("Scene1") == "some_state" {
+		t.Errorf("Scenario state updated after pause")
+	}
+
+	ms.ResetAll()
+	if ms.GetPaused() {
+		t.Errorf("Scenarios not unpaused after all were reset")
 	}
 
 }


### PR DESCRIPTION
When building mocks for developing a web ui against setting and pausing state to stay in the middle of a scenario would be super handy... so here it is.

Hope this meets all standards, happy to make any improvements first.