### PR TITLE
Use builder/runtime pattern in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine
+FROM golang:1.9-alpine as builder
 
 # Install ca-certificates, required for the "release message" feature:
 RUN apk --no-cache add \
@@ -12,6 +12,13 @@ RUN apk --no-cache add --virtual build-dependencies \
   && mv /root/gocode/bin/mmock /usr/local/bin \
   && rm -rf /root/gocode \
   && apk del --purge build-dependencies
+
+FROM alpine:3.6
+
+RUN apk --no-cache add \
+    ca-certificates
+
+COPY --from=builder /usr/local/bin/mmock /usr/local/bin/mmock
 
 RUN mkdir /config
 RUN mkdir /tls

--- a/definition/config_mapper_test.go
+++ b/definition/config_mapper_test.go
@@ -35,31 +35,31 @@ func TestReadMockDefinition(t *testing.T) {
 	content := []byte(MockContent)
 	dir, err := ioutil.TempDir("", "mmock")
 	if err != nil {
-		t.Errorf("Error creating temporary folder")
+		t.Error("Error creating temporary folder")
 	}
 
 	tmpfn := filepath.Join(dir, "tmpfile_1")
 	if err := ioutil.WriteFile(tmpfn, content, 0666); err != nil {
-		t.Errorf("Error creating temporary file")
+		t.Error("Error creating temporary file")
 	}
 
 	defer os.RemoveAll(dir) // clean up
 
 	mapper := NewConfigMapper()
 	if _, err := mapper.Read(tmpfn); err == nil {
-		t.Errorf("Expected read error")
+		t.Error("Expected read error")
 	}
 
 	mapper = NewConfigMapper()
 	mapper.AddConfigParser(&mockParser{canParse: false, readOk: false})
 	if _, err := mapper.Read(tmpfn); err == nil {
-		t.Errorf("Expected read error")
+		t.Error("Expected read error")
 	}
 
 	mapper = NewConfigMapper()
 	mapper.AddConfigParser(&mockParser{canParse: true, readOk: false})
 	if _, err := mapper.Read(tmpfn); err == nil {
-		t.Errorf("Expected read error")
+		t.Error("Expected read error")
 	}
 	mapper = NewConfigMapper()
 	mapper.AddConfigParser(&mockParser{canParse: true, readOk: true})
@@ -81,12 +81,12 @@ func TestWriteMockDefinition(t *testing.T) {
 	mapper := NewConfigMapper()
 	err = mapper.Write(tmpfn, mock)
 	if err != nil {
-		t.Errorf("Unexpected error writing the config", err)
+		t.Error("Unexpected error writing the config", err)
 	}
 
 	bytes, erf := ioutil.ReadFile(tmpfn)
 	if erf != nil || len(bytes) == 0 {
-		t.Errorf("Unexpected error reading the config ", erf)
+		t.Error("Unexpected error reading the config ", erf)
 	}
 
 }

--- a/definition/parser/yaml_reader_test.go
+++ b/definition/parser/yaml_reader_test.go
@@ -65,89 +65,89 @@ control:
 	yaml := YAMLReader{}
 	m, err := yaml.Parse(invalidDefinition)
 	if err == nil {
-		t.Errorf("Expected error in definition")
+		t.Error("Expected error in definition")
 	}
 
 	m, err = yaml.Parse(validDefinition)
 	if err != nil {
-		t.Errorf("Unexpected error in definition", err)
+		t.Error("Unexpected error in definition", err)
 	}
 
 	if m.URI != "name" {
-		t.Errorf("Missing name")
+		t.Error("Missing name")
 	}
 
 	if m.Description != "description" {
-		t.Errorf("Missing description")
+		t.Error("Missing description")
 	}
 
 	//request
 	if m.Request.Method != "GET" {
-		t.Errorf("Missing description")
+		t.Error("Missing description")
 	}
 
 	if m.Request.Path != "/your/path/:variable" {
-		t.Errorf("Missing description")
+		t.Error("Missing description")
 	}
 
 	if m, f := m.Request.QueryStringParameters["name"]; f == false || m[0] != "value" {
-		t.Errorf("Missing QueryStringParameters")
+		t.Error("Missing QueryStringParameters")
 	}
 
 	if m, f := m.Request.Headers["name"]; f == false || m[0] != "value" {
-		t.Errorf("Missing Headers")
+		t.Error("Missing Headers")
 	}
 
 	if m, f := m.Request.Cookies["name"]; f == false || m != "value" {
-		t.Errorf("Missing Cookies")
+		t.Error("Missing Cookies")
 	}
 
 	if m.Request.Body != "Expected Body" {
-		t.Errorf("Missing Body")
+		t.Error("Missing Body")
 	}
 
 	//response
 	if m.Response.StatusCode != 200 {
-		t.Errorf("statusCode")
+		t.Error("statusCode")
 	}
 	if m, f := m.Response.Headers["name"]; f == false || m[0] != "value" {
-		t.Errorf("Missing Headers")
+		t.Error("Missing Headers")
 	}
 	if m, f := m.Response.Cookies["name"]; f == false || m != "value" {
-		t.Errorf("Missing Cookies")
+		t.Error("Missing Cookies")
 	}
 	if m.Response.Body != "Responsebody" {
-		t.Errorf("Missing Body")
+		t.Error("Missing Body")
 	}
 
 	//control
 
 	if m.Control.ProxyBaseURL != "http://www.jordi.io" {
-		t.Errorf("Missing ProxyBaseURL")
+		t.Error("Missing ProxyBaseURL")
 	}
 
 	if m.Control.Delay != 5 {
-		t.Errorf("Missing delay")
+		t.Error("Missing delay")
 	}
 
 	if m.Control.Crazy != true {
-		t.Errorf("Missing crazy")
+		t.Error("Missing crazy")
 	}
 
 	if m.Control.Priority != 1 {
-		t.Errorf("Missing Priority")
+		t.Error("Missing Priority")
 	}
 
 	if m.Control.Scenario.Name != "string (scenario name)" {
-		t.Errorf("Missing scenario name")
+		t.Error("Missing scenario name")
 	}
 
 	if m.Control.Scenario.RequiredState[1] != "another_state_name" {
-		t.Errorf("Missing scenario RequiredState")
+		t.Error("Missing scenario RequiredState")
 	}
 
 	if m.Control.Scenario.NewState != "new_stat_neme" {
-		t.Errorf("Missing scenario NewState")
+		t.Error("Missing scenario NewState")
 	}
 
 }

--- a/server/dispatcher.go
+++ b/server/dispatcher.go
@@ -60,7 +60,7 @@ func (di Dispatcher) callWebHook(url string, match *definition.Match) {
 		log.Printf("Impossible send payload to: %s\n", url)
 		return
 	}
-	log.Print("WebHook response: %s\n", resp.StatusCode)
+	log.Printf("WebHook response: %d\n", resp.StatusCode)
 }
 
 //ServerHTTP is the mock http server request handler.
@@ -117,11 +117,11 @@ func (di *Dispatcher) getMatchingResult(request *definition.Request) (*definitio
 
 			di.Processor.Eval(request, mock)
 			if mock.Control.Crazy {
-				log.Printf("Running crazy mode")
+				log.Println("Running crazy mode")
 				mock.Response.StatusCode = di.randomStatusCode(mock.Response.StatusCode)
 			}
 			if mock.Control.Delay > 0 {
-				log.Printf("Adding a delay")
+				log.Println("Adding a delay")
 				time.Sleep(time.Duration(mock.Control.Delay) * time.Second)
 			}
 


### PR DESCRIPTION
Creates runtime image without full go tooling in it; only 15 megs instead of 280 megs.

Also cleans up go vet errors around Error/Errorf and Print/Printf so it will build on go1.10