### PR TITLE
Problem: can't use custom ca certs in mmock server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN mkdir /tls
 
 VOLUME /config
 
-ADD ./tls/server.crt /tls 
-ADD ./tls/server.key /tls 
+ADD ./tls/server.crt /tls
+ADD ./tls/server.key /tls
 
 EXPOSE 8082 8083 8084
 


### PR DESCRIPTION
Solution: allow a 'ca.crt' to be part of the tls directory and loaded
as the certpool for the tls config on the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmartin82/mmock/54)
<!-- Reviewable:end -->
