### PR TITLE
VRS-1013 if a mock path is /whatever/* use the value of * for the proxy

### DIFF
--- a/server/dispatcher.go
+++ b/server/dispatcher.go
@@ -21,6 +21,8 @@ import (
 	"github.com/jmartin82/mmock/statistics"
 	"github.com/jmartin82/mmock/translate"
 	"github.com/jmartin82/mmock/vars"
+	"strings"
+	"net/url"
 )
 
 //Dispatcher is the mock http server
@@ -101,8 +103,17 @@ func getProxyResponse(request *definition.Request, mock *definition.Mock) *defin
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
+
 	client := &http.Client{Transport: tr}
-	pr := proxy.Proxy{URL: mock.Control.ProxyBaseURL, Client: client}
+	mockProxyBaseURL := mock.Control.ProxyBaseURL
+
+	if strings.Contains(mock.Request.Path, "*") {
+		parsedMockProxyBaseURL, _ := url.Parse(mockProxyBaseURL)
+		mockProxyBaseURL = parsedMockProxyBaseURL.Scheme + "://" + parsedMockProxyBaseURL.Host + request.Path
+	}
+
+	pr := proxy.Proxy{URL: mockProxyBaseURL, Client: client}
+
 	return pr.MakeRequest(request)
 }
 


### PR DESCRIPTION
@jmartin82 I did this change in order to change the behavior of the proxy when the mock path contains '*'

For the mock I copied at the bottom of my comment, the behavior on production is that any request that matches the path `papipay/*` (/papipay/girl, /papipay/video...) will be proxied to "http://dev.members.badoink.com/papipay/". This is **not** wrong but I am not sure if it makes much sense proxying all these different requests to the same url. With my change, the same mock copied below would proxy the following request:
```http://192.168.20.133:8083/papipay/girls?paysite_name=badoinkvr```
to:
```http://dev.members.badoink.com/papipay/girls?paysite_name=badoinkvr```

What do you think? Feel free to accept this change, improve or reject it. We could implement a solution for this in our side as well.

```
request:
  method: GET
  path: /papipay/*

control:
  proxyBaseURL: "http://dev.members.badoink.com/papipay/"
  priority: 2

```
