### PR TITLE
Matching state without case

### DIFF
--- a/match/tester.go
+++ b/match/tester.go
@@ -127,7 +127,7 @@ func (mm Tester) matchScenarioState(scenario *definition.Scenario) bool {
 
 	currentState := mm.Scenario.GetState(scenario.Name)
 	for _, r := range scenario.RequiredState {
-		if r == currentState {
+		if strings.ToLower(r) == currentState {
 			return true
 		}
 	}

--- a/match/tester_test.go
+++ b/match/tester_test.go
@@ -483,6 +483,23 @@ func TestSceneMatchingDefinition(t *testing.T) {
 	}
 }
 
+func TestSceneMatchingIgnoreStateCase(t *testing.T) {
+	req := definition.Request{}
+	req.Body = "HelloWorld"
+	m := definition.Mock{}
+	m.Control.Scenario.Name = "uSEr"
+	m.Control.Scenario.RequiredState = []string{"CreAted"}
+	s := scenario.NewMemoryStore()
+	mm := Tester{Scenario: s}
+	if b, _ := mm.Check(&req, &m, true); b {
+		t.Error("Scenario doesn't match")
+	}
+	s.SetState("user", "created")
+	if b, _ := mm.Check(&req, &m, true); !b {
+		t.Error("Scenario match")
+	}
+}
+
 func TestSceneMatchingDefinitionDisabled(t *testing.T) {
 	req := definition.Request{}
 	req.Body = "HelloWorld"


### PR DESCRIPTION
# Overview
Fix problem that state doesn't match if state include Upper case.

# Example
There are 2 mock definitions(excerpt about scenario).
I call Definition2 mock after Definition1 mock, Definition2 doesn't match for state problem.

## Definition1
```json
{
	"control": {
		"scenario": {
			"name": "test",
			"requiredState": [
				"not_started"
			],
			"newState": "Test"
		}
	}
}
```
## Definition2
```json
{
	"control": {
		"scenario": {
			"name": "test",
			"requiredState": [
				"Test"
			]
		}
	}
}
```

# Code
When Mmock store state, Mmock transfer state value to lower case.
https://github.com/jmartin82/mmock/blob/19f7e4cd68438dee8c92b725db543adc96c12b7b/scenario/memory_store.go#L30-L34

But when Tester check required state, Tester use original state value.
https://github.com/jmartin82/mmock/blob/19f7e4cd68438dee8c92b725db543adc96c12b7b/match/tester.go#L123-L136

