### PR TITLE
Use an array of holders for every tag to allow duplicates

### DIFF
--- a/vars/fake.go
+++ b/vars/fake.go
@@ -126,9 +126,9 @@ func (fv Fake) getMethodAndParameters(input string) (method string, parameters [
 	return
 }
 
-func (fv Fake) Fill(holders []string) map[string]string {
+func (fv Fake) Fill(holders []string) map[string][]string {
 
-	vars := make(map[string]string)
+	vars := make(map[string][]string)
 	for _, tag := range holders {
 		found := false
 		s := ""
@@ -137,7 +137,7 @@ func (fv Fake) Fill(holders []string) map[string]string {
 		}
 
 		if found {
-			vars[tag] = s
+			vars[tag] = append(vars[tag], s)
 		}
 
 	}

--- a/vars/filler.go
+++ b/vars/filler.go
@@ -1,5 +1,5 @@
 package vars
 
 type Filler interface {
-	Fill(holders []string) map[string]string
+	Fill(holders []string) map[string][]string
 }

--- a/vars/processor.go
+++ b/vars/processor.go
@@ -42,7 +42,7 @@ func (fp Processor) walkAndGet(res definition.Response) []string {
 	return vars
 }
 
-func (fp Processor) walkAndFill(m *definition.Mock, vars map[string]string) {
+func (fp Processor) walkAndFill(m *definition.Mock, vars map[string][]string) {
 	res := &m.Response
 	for header, values := range res.Headers {
 		for i, value := range values {
@@ -57,11 +57,13 @@ func (fp Processor) walkAndFill(m *definition.Mock, vars map[string]string) {
 	res.Body = fp.replaceVars(res.Body, vars)
 }
 
-func (fp Processor) replaceVars(input string, vars map[string]string) string {
+func (fp Processor) replaceVars(input string, vars map[string][]string) string {
 	return varsRegex.ReplaceAllStringFunc(input, func(value string) string {
 		varName := strings.Trim(value, "{} ")
 		// replace the strings
-		if r, found := vars[varName]; found {
+		if v, found := vars[varName]; found {
+			r := v[0]
+			vars[varName] = v[1:]
 			return r
 		}
 		// replace regexes
@@ -78,7 +80,7 @@ func (fp Processor) extractVars(input string, vars *[]string) {
 	}
 }
 
-func (fp Processor) mergeVars(org map[string]string, vals map[string]string) {
+func (fp Processor) mergeVars(org map[string][]string, vals map[string][]string) {
 	for k, v := range vals {
 		org[k] = v
 	}

--- a/vars/request.go
+++ b/vars/request.go
@@ -17,9 +17,9 @@ type Request struct {
 	Request *definition.Request
 }
 
-func (rp Request) Fill(holders []string) map[string]string {
+func (rp Request) Fill(holders []string) map[string][]string {
 
-	vars := make(map[string]string)
+	vars := make(map[string][]string)
 	for _, tag := range holders {
 		found := false
 		s := ""
@@ -53,7 +53,7 @@ func (rp Request) Fill(holders []string) map[string]string {
 		}
 
 		if found {
-			vars[tag] = s
+			vars[tag] = append(vars[tag], s)
 		}
 
 	}

--- a/vars/stream.go
+++ b/vars/stream.go
@@ -14,14 +14,14 @@ var re = regexp.MustCompile(`(?m)\((.*)\)`)
 type Stream struct {
 }
 
-func (st Stream) Fill(holders []string) map[string]string {
+func (st Stream) Fill(holders []string) map[string][]string {
 
-	vars := make(map[string]string)
+	vars := make(map[string][]string)
 	for _, tag := range holders {
 		if strings.HasPrefix(tag, "file.contents(") {
-			vars[tag] = st.getOutput(st.getFileContents(tag))
+			vars[tag] = append(vars[tag], st.getOutput(st.getFileContents(tag)))
 		} else if strings.HasPrefix(tag, "http.contents(") {
-			vars[tag] = st.getOutput(st.getHttpContents(tag))
+			vars[tag] = append(vars[tag], st.getOutput(st.getHttpContents(tag)))
 		}
 	}
 	return vars

--- a/vars/stream_test.go
+++ b/vars/stream_test.go
@@ -35,7 +35,7 @@ func TestReadFile(t *testing.T) {
 		t.Errorf("Stream key not found")
 	}
 
-	if !strings.Contains(v, "This is a big file") {
+	if !strings.Contains(v[0], "This is a big file") {
 		t.Errorf("Couldn't get the content. Value: %s", v)
 	}
 
@@ -53,7 +53,7 @@ func TestHTTPContent(t *testing.T) {
 		t.Errorf("Stream key not found")
 	}
 
-	if !strings.Contains(v, "Example Domain") {
+	if !strings.Contains(v[0], "Example Domain") {
 		t.Errorf("Couldn't get the content. Value: %s", v)
 	}
 }
@@ -70,7 +70,7 @@ func TestError(t *testing.T) {
 		t.Errorf("Stream key not found")
 	}
 
-	if !strings.Contains(v, "ERROR: open XXXXX: no such file or directory") {
+	if !strings.Contains(v[0], "ERROR: open XXXXX: no such file or directory") {
 		t.Errorf("Couldn't get the content. Value: %s", v)
 	}
 }


### PR DESCRIPTION
This change allows having repeated tags in the definitions

Fixes issue #66 