### PR TITLE
Add a method to paginate the requests

### DIFF
--- a/match/memory_store.go
+++ b/match/memory_store.go
@@ -35,6 +35,26 @@ func (mrs *MemoryStore) GetAll() []definition.Match {
 	return r
 }
 
+//Get return an subset of current matches (positive and negative) in memory
+func (mrs *MemoryStore) Get(limit uint, offset uint) []definition.Match {
+	mrs.Lock()
+	defer mrs.Unlock()
+
+	max := offset + limit
+	if max > uint(len(mrs.matches)) {
+		max = uint(len(mrs.matches))
+	}
+
+	if offset >= max {
+		return []definition.Match{}
+	}
+
+	r := make([]definition.Match, max-offset)
+	copy(r, mrs.matches[offset:max])
+
+	return r
+}
+
 //NewMemoryStore is the MemoryStore contructor
 func NewMemoryStore() *MemoryStore {
 	reqs := make([]definition.Match, 0, 100)

--- a/match/memory_store_test.go
+++ b/match/memory_store_test.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jmartin82/mmock/definition"
@@ -46,6 +47,76 @@ func TestGetAll(t *testing.T) {
 
 	if len(reqs) != 0 {
 		t.Fatalf("Invalid store len: %v", len(reqs))
+	}
+}
+
+func TestGet(t *testing.T) {
+
+	msr := NewMemoryStore()
+
+	matches := []definition.Match{
+		{Time: 1},
+		{Time: 2},
+		{Time: 3},
+		{Time: 4},
+		{Time: 5},
+	}
+	for _, m := range matches {
+		msr.Save(m)
+	}
+
+	tests := []struct {
+		msg      string
+		limit    uint
+		offset   uint
+		expected []definition.Match
+	}{
+		{"Zero limit and offset", 0, 0, []definition.Match{}},
+		{"Zero limit and one offset", 0, 1, []definition.Match{}},
+		{"Grab the first element", 1, 0, []definition.Match{{Time: 1}}},
+		{"Grab second element", 1, 1, []definition.Match{{Time: 2}}},
+		{"Grab first two elements", 2, 0, []definition.Match{{Time: 1}, {Time: 2}}},
+		{"Grab the second and the third elements", 2, 1, []definition.Match{{Time: 2}, {Time: 3}}},
+		{"Grab the last elements", 1, 4, []definition.Match{{Time: 5}}},
+		{"Grab the last two elements", 2, 3, []definition.Match{{Time: 4}, {Time: 5}}},
+		{"Out of bounds offset", 1, 5, []definition.Match{}},
+		{"Out of bounds limit", 2, 4, []definition.Match{{Time: 5}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			r := msr.Get(tt.limit, tt.offset)
+			if !reflect.DeepEqual(r, tt.expected) {
+				t.Errorf("Wrong definitions: got %v, want %v", r, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetOnEmptyStore(t *testing.T) {
+
+	msr := NewMemoryStore()
+
+	tests := []struct {
+		msg      string
+		limit    uint
+		offset   uint
+		expected []definition.Match
+	}{
+		{"Zero limit and offset", 0, 0, []definition.Match{}},
+		{"Zero limit and one offset", 0, 1, []definition.Match{}},
+		{"Out of bounds offset", 0, 1, []definition.Match{}},
+		{"Out of bounds limit", 1, 0, []definition.Match{}},
+		{"Out of bounds", 1, 1, []definition.Match{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			r := msr.Get(tt.limit, tt.offset)
+			if !reflect.DeepEqual(r, tt.expected) {
+				t.Errorf("Wrong definitions: got %v, want %v", r, tt.expected)
+			}
+		})
 	}
 }
 

--- a/match/spy.go
+++ b/match/spy.go
@@ -34,6 +34,10 @@ func (mc Spy) GetAll() []definition.Match {
 	return mc.store.GetAll()
 }
 
+func (mc Spy) Get(limit uint, offset uint) []definition.Match {
+	return mc.store.Get(limit, offset)
+}
+
 func (mc Spy) GetMatched() []definition.Match {
 	return mc.getMatchByResult(true)
 }

--- a/match/store.go
+++ b/match/store.go
@@ -8,4 +8,5 @@ type Store interface {
 	Save(definition.Match)
 	Reset()
 	GetAll() []definition.Match
+	Get(limit uint, offset uint) []definition.Match
 }

--- a/mmock.go
+++ b/mmock.go
@@ -133,14 +133,16 @@ func startServer(ip string, port, portTLS int, configTLS string, done chan bool,
 	dispatcher.Start()
 	done <- true
 }
-func startConsole(ip string, port int, spy match.Spier, scenario scenario.Director, mapping definition.Mapping, done chan bool, mLog chan definition.Match) {
+func startConsole(ip string, port int, resultsPerPage uint, spy match.Spier, scenario scenario.Director, mapping definition.Mapping, done chan bool, mLog chan definition.Match) {
 	dispatcher := console.Dispatcher{
-		IP:       ip,
-		Port:     port,
-		MatchSpy: spy,
-		Scenario: scenario,
-		Mapping:  mapping,
-		Mlog:     mLog}
+		IP:             ip,
+		Port:           port,
+		MatchSpy:       spy,
+		Scenario:       scenario,
+		Mapping:        mapping,
+		Mlog:           mLog,
+		ResultsPerPage: resultsPerPage,
+	}
 	dispatcher.Start()
 	done <- true
 }
@@ -163,6 +165,7 @@ func main() {
 	console := flag.Bool("console", true, "Console enabled  (true/false)")
 	cPath := flag.String("config-path", path, "Mocks definition folder")
 	cTLS := flag.String("tls-path", TLS, "TLS config folder (server.crt and server.key should be inside)")
+	cResultsPerPage := flag.Uint("results-per-page", 25, "Number of results per page")
 
 	flag.Parse()
 
@@ -190,7 +193,7 @@ func main() {
 	log.Printf("HTTP Server running at %s:%d\n", *sIP, *sPort)
 	log.Printf("HTTPS Server running at %s:%d\n", *sIP, *sPortTLS)
 	if *console {
-		go startConsole(*cIP, *cPort, spy, scenario, mapping, done, mLog)
+		go startConsole(*cIP, *cPort, *cResultsPerPage, spy, scenario, mapping, done, mLog)
 		log.Printf("Console running at %s:%d\n", *cIP, *cPort)
 	}
 


### PR DESCRIPTION
With these changes you can get all recorded requests paginated from the console. 
The change adds a new route so its backward compatible.

Adds requested feature #67 