### PR TITLE
Add reset match endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,33 @@ This makes it possible to verify that a request matching a specific pattern was 
 **Method** : GET<br>
 **Response Codes**: Success (200 OK)<br>
 
+**Title** : Reset all requests that match with an specific pattern.<br>
+**URL** : /api/request/reset_match<br>
+**Method** : POST<br>
+**Data Params**:  <br>
+
+Like stubbing this call also uses the same DSL to filter and query requests.
+
+```json
+{
+	"host": "example.com",
+	"method": "GET|POST|PUT|PATCH|... (Mandatory)", 
+	"path": "/your/path/:variable (Mandatory)",
+	"queryStringParameters": {
+		"name": ["value"],
+		"name": ["value", "value"]
+	},
+	"headers": {
+		"name": ["value"]
+	},
+	"cookies": {
+		"name": "value"
+	},
+	"body": "Expected Body"
+}
+```
+**Response Codes**: Success (200 OK)<br>
+
 **Title** : Get all non matched requests.<br>
 **URL** : /api/request/unmatched<br>
 **Method** : GET<br>

--- a/console/dispatcher.go
+++ b/console/dispatcher.go
@@ -82,6 +82,7 @@ func (di *Dispatcher) Start() {
 	//verification
 	e.GET("/api/request/reset", di.requestResetHandler)
 	e.POST("/api/request/verify", di.requestVerifyHandler)
+	e.POST("/api/request/reset_match", di.resetMatchHandler)
 	e.GET("/api/request/all", di.requestAllHandler)
 	e.GET("/api/request/all/:page", di.requestAllPagedHandler)
 	e.GET("/api/request/matched", di.requestMatchedHandler)
@@ -249,6 +250,21 @@ func (di *Dispatcher) requestVerifyHandler(c echo.Context) error {
 	}
 	result := di.MatchSpy.Find(dReq)
 	return c.JSON(http.StatusOK, result)
+}
+
+func (di *Dispatcher) resetMatchHandler(c echo.Context) error {
+	statistics.TrackVerifyRequest()
+	dReq := definition.Request{}
+	if err := c.Bind(&dReq); err != nil {
+		return err
+	}
+
+	ar := &ActionResponse{
+		Result: "reset match",
+	}
+
+	di.MatchSpy.ResetMatch(dReq)
+	return c.JSON(http.StatusOK, ar)
 }
 
 func (di *Dispatcher) requestResetHandler(c echo.Context) error {

--- a/match/memory_store.go
+++ b/match/memory_store.go
@@ -27,7 +27,7 @@ func (mrs *MemoryStore) Reset() {
 	mrs.Unlock()
 }
 
-//Reset clean the request stored in memory that matches a particular criteria
+//ResetMatch clean the request stored in memory that matches a particular criteria
 func (mrs *MemoryStore) ResetMatch(req definition.Request) {
 	matches := mrs.GetAll()
 	mrs.Lock()

--- a/match/spy.go
+++ b/match/spy.go
@@ -23,6 +23,7 @@ func (mc Spy) Find(r definition.Request) []definition.Match {
 
 }
 
+// ResetMatch ...
 func (mc Spy) ResetMatch(r definition.Request) {
 	mc.store.ResetMatch(r)
 }

--- a/match/spy.go
+++ b/match/spy.go
@@ -23,6 +23,10 @@ func (mc Spy) Find(r definition.Request) []definition.Match {
 
 }
 
+func (mc Spy) ResetMatch(r definition.Request) {
+	mc.store.ResetMatch(r)
+}
+
 func (mc Spy) Save(match definition.Match) {
 	mc.store.Save(match)
 }

--- a/match/spy_test.go
+++ b/match/spy_test.go
@@ -31,7 +31,7 @@ func (dsm DummyScenarioManager) SetPaused(_ bool) {
 }
 
 func TestFindMatches(t *testing.T) {
-	spy := NewSpy(NewTester(payload.NewComparator(), DummyScenarioManager{}), NewMemoryStore())
+	spy := NewSpy(NewTester(payload.NewComparator(), DummyScenarioManager{}), NewMemoryStore(DummyMatcher{}))
 
 	m1 := definition.Match{Request: &definition.Request{Host: "TEST1"}}
 	spy.Save(m1)
@@ -55,7 +55,7 @@ func TestFindMatches(t *testing.T) {
 }
 
 func TestMatchByResult(t *testing.T) {
-	spy := NewSpy(NewTester(payload.NewComparator(), DummyScenarioManager{}), NewMemoryStore())
+	spy := NewSpy(NewTester(payload.NewComparator(), DummyScenarioManager{}), NewMemoryStore(DummyMatcher{}))
 
 	m1 := definition.Match{Result: &definition.MatchResult{Found: true}}
 	spy.Save(m1)

--- a/match/store.go
+++ b/match/store.go
@@ -7,6 +7,7 @@ import (
 type Store interface {
 	Save(definition.Match)
 	Reset()
+	ResetMatch(definition.Request)
 	GetAll() []definition.Match
 	Get(limit uint, offset uint) []definition.Match
 }

--- a/mmock.go
+++ b/mmock.go
@@ -178,7 +178,7 @@ func main() {
 	scenario := scenario.NewMemoryStore()
 	comparator := payload.NewDefaultComparator()
 	tester := match.NewTester(comparator, scenario)
-	matchStore := match.NewMemoryStore()
+	matchStore := match.NewMemoryStore(tester)
 	mapping := getMapping(*cPath)
 	spy := getMatchSpy(tester, matchStore)
 	router := getRouter(mapping, tester)

--- a/tmpl/swagger.json
+++ b/tmpl/swagger.json
@@ -98,6 +98,27 @@
         }
       }
     },
+    "/request/reset_match": {
+      "get": {
+        "summary": "Reset stored requests that matches specific criteria",
+        "tags": [
+          "request"
+        ],
+        "operationId": "Reset stored requests with criteria",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ActionResponse"
+            }
+          }
+        }
+      }
+    },
     "/request/unmatched": {
       "get": {
         "summary": "Get all unmatched requests",


### PR DESCRIPTION
Reset clean the request stored in memory that matches a particular criteria.
Like stubbing this call also uses the same DSL to filter and query requests.

Thanks for this awesome project @jmartincmp ❤️ 