### PR TITLE
Add support for environment variables

### DIFF
--- a/config/env.yaml
+++ b/config/env.yaml
@@ -1,0 +1,14 @@
+request: 
+  method: GET
+  path: /env
+response:
+  statusCode: 200
+  headers:
+    Content-Type: 
+      - "application/json"
+  body: >
+    [
+      {  
+        "test":"{{env.TEST_ENV_VARIABLE}}"
+      }
+    ]

--- a/internal/vars/request.go
+++ b/internal/vars/request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jmartin82/mmock/pkg/mock"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -50,6 +51,8 @@ func (rp Request) Fill(holders []string) map[string][]string {
 			s, found = rp.getCookieParam(tag[15:])
 		} else if strings.HasPrefix(tag, "request.header.") {
 			s, found = rp.getHeaderParam(tag[15:])
+		} else if strings.HasPrefix(tag, "env.") {
+			s, found = os.LookupEnv(tag[4:])
 		}
 
 		if found {

--- a/internal/vars/request_test.go
+++ b/internal/vars/request_test.go
@@ -2,6 +2,7 @@ package vars
 
 import (
 	"github.com/jmartin82/mmock/pkg/mock"
+	"os"
 	"strings"
 	"testing"
 )
@@ -50,5 +51,57 @@ func TestGetHeaderParamWithOutHeaderValue(t *testing.T) {
 
 	if strings.EqualFold(v, "Bearer abc1235") {
 		t.Errorf("Couldn get the content. Value: %s", v)
+	}
+}
+
+func TestGetEnvironmentVariable(t *testing.T) {
+	key := "env.TEST_VARIABLE"
+	value := "test value"
+
+	holders := []string{
+		key,
+	}
+
+	rp := Request{}
+
+	os.Setenv("TEST_VARIABLE", value)
+	vars := rp.Fill(holders)
+	os.Unsetenv("TEST_VARIABLE")
+
+	if len(vars) == 0 {
+		t.Errorf("Unable to retrieve vars")
+	}
+
+	v, ok := vars[key]
+
+	if !ok {
+		t.Errorf("Unable to retrieve value inside vars")
+	}
+
+	if len(v[0]) == 0 {
+		t.Errorf("Unable to retrieve value inside var element")
+	}
+
+	if !strings.EqualFold(v[0], value) {
+		t.Errorf("Couldn't get the expected value. Expected: %s, Value found: %s", value, v[0])
+	}
+}
+
+func TestGetEnvironmentVariableNotFound(t *testing.T) {
+	key := "env.TEST_VARIABLE_UNEXISTENT"
+	value := "test value"
+
+	holders := []string{
+		key,
+	}
+
+	rp := Request{}
+	
+	os.Setenv("TEST_VARIABLE", value)
+	vars := rp.Fill(holders)
+	os.Unsetenv("TEST_VARIABLE")
+
+	if len(vars) > 0 {
+		t.Errorf("Unexpectedly found variable")
 	}
 }


### PR DESCRIPTION
We'd like to "template" our mappings in order to make them configurable via Environment variables (mainly to be used inside a Docker Container).

This PR adds the possibility to retrieve env vars inside the mappings using `{{env.ENV_NAME}}`.