### PR TITLE
Mmock expects "=" separator for parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ COPY mmock /usr/local/bin/mmock
 
 EXPOSE 8082 8083 8084
 
-ENTRYPOINT ["mmock","-config-path","/config","-tls-path","/tls"]
-CMD ["-server-ip","0.0.0.0","-console-ip","0.0.0.0"]
+ENTRYPOINT ["mmock","-config-path=/config","-tls-path=/tls"]
+CMD ["-server-ip=0.0.0.0","-console-ip=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To configure Mmock, use command line flags described in help.
     Usage of ./mmock:
 	  -config-path=string
 		Mocks definition folder (default "execution_pathconfig")
-	  -console
+	  -console=boolean
 		Console enabled  (true/false) (default true)
 	  -console-ip=string
 		Console server IP (default "public_ip")
@@ -114,7 +114,7 @@ To configure Mmock, use command line flags described in help.
 		Mock server IP (default "public_ip")
 	  -server-port=int
 		Mock server Port (default 8083)
-	  -server-statistics
+	  -server-statistics=boolean
 		Mock server sends anonymous statistics (default true)
 	  -server-tls-port=int
 		Mock server TLS Port (default 8084)

--- a/README.md
+++ b/README.md
@@ -100,25 +100,25 @@ To configure Mmock, use command line flags described in help.
 
 ```
     Usage of ./mmock:
-	  -config-path string
+	  -config-path=string
 		Mocks definition folder (default "execution_pathconfig")
 	  -console
 		Console enabled  (true/false) (default true)
-	  -console-ip string
+	  -console-ip=string
 		Console server IP (default "public_ip")
-	  -console-port int
+	  -console-port=int
 		Console server Port (default 8082)
-	  -results-per-page uint
+	  -results-per-page=uint
 		Number of results per page (default 25)
-	  -server-ip string
+	  -server-ip=string
 		Mock server IP (default "public_ip")
-	  -server-port int
+	  -server-port=int
 		Mock server Port (default 8083)
 	  -server-statistics
 		Mock server sends anonymous statistics (default true)
-	  -server-tls-port int
+	  -server-tls-port=int
 		Mock server TLS Port (default 8084)
-	  -tls-path string
+	  -tls-path=string
 		TLS config folder (server.crt and server.key should be inside) (default "execution_path/tls")
 ```
 


### PR DESCRIPTION
Hi,

I needed to change the default network interface mmock connects to for the console by using `-console-ip 127.0.0.1` after following the documentation.

I realised it didn't work as it would seem mmock expects "=" separated parameters.

I have update the documentation and the Dockerfile to reflect this realisation :)

Hope this helps.

Thanks !