### PR TITLE
Add curl to image to let healthcheck actually run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 
 RUN apk --no-cache add \
-    ca-certificates
+    ca-certificates curl
 
 RUN mkdir /config
 RUN mkdir /tls


### PR DESCRIPTION
The healthchecks run inside the container, so needs all tools necessary to let the healthcheck run. The alpine image doesn't have curl installed, so the healthcheck never had a chance to succeed. This adds curl, letting the healthcheck pass.