### PR TITLE
Return error while parsing duration during unmarshalling

### DIFF
--- a/internal/config/parser/json_reader_test.go
+++ b/internal/config/parser/json_reader_test.go
@@ -137,8 +137,7 @@ func TestJSONRead(t *testing.T) {
 		t.Errorf("Missing ProxyBaseURL")
 	}
 
-	d, _ := m.Control.Delay.Duration()
-	if d != 50*time.Millisecond {
+	if m.Control.Delay.Duration != 50*time.Millisecond {
 		t.Errorf("Missing delay")
 	}
 

--- a/internal/config/parser/yaml_reader_test.go
+++ b/internal/config/parser/yaml_reader_test.go
@@ -129,8 +129,7 @@ control:
 		t.Error("Missing ProxyBaseURL")
 	}
 
-	d, _ := m.Control.Delay.Duration()
-	if d != 5*time.Second {
+	if m.Control.Delay.Duration != 5*time.Second {
 		t.Errorf("Missing delay")
 	}
 

--- a/internal/server/dispatcher.go
+++ b/internal/server/dispatcher.go
@@ -144,8 +144,8 @@ func (di *Dispatcher) getMatchingResult(request *mock.Request) (*mock.Definition
 				mock.Response.StatusCode = di.randomStatusCode(mock.Response.StatusCode)
 			}
 
-			if d, err := mock.Control.Delay.Duration(); err == nil && d > 0 {
-				log.Printf("Adding a delay of: %s\n", d.String())
+			if d := mock.Control.Delay.Duration; d > 0 {
+				log.Printf("Adding a delay of: %s\n", d)
 				time.Sleep(d)
 			}
 

--- a/pkg/mock/definition.go
+++ b/pkg/mock/definition.go
@@ -59,7 +59,7 @@ func (d *Delay) UnmarshalJSON(data []byte) (err error) {
 		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 		fmt.Println("! DEPRECATION NOTICE:                                        !")
 		fmt.Println("! Please use a time unit (m,s,ms) to define the delay value. !")
-		fmt.Println("! Ex: \"delay\":\"1ms\" instead \"delay\":1                  !")
+		fmt.Println("! Ex: \"delay\":\"1s\" instead \"delay\":1                   !")
 		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 	case string:
 		s = v.(string)

--- a/pkg/mock/definition_test.go
+++ b/pkg/mock/definition_test.go
@@ -1,0 +1,73 @@
+package mock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJSONParseDelay(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		exp  time.Duration
+		err  bool
+	}{
+		{
+			name: "null",
+			in:   "null",
+			err:  true,
+		}, {
+			name: "empty string",
+			in:   `""`,
+			err:  true,
+		}, {
+			name: "object",
+			in:   "{}",
+			err:  true,
+		}, {
+			name: "array",
+			in:   "[]",
+			err:  true,
+		}, {
+			name: "float 1",
+			in:   "1.00",
+			exp:  time.Second,
+		}, {
+			name: "float >1",
+			in:   "1.2",
+			exp:  time.Second,
+		}, {
+			name: "float <1",
+			in:   "0.6",
+		}, {
+			name: "int",
+			in:   "5",
+			exp:  time.Second * 5,
+		}, {
+			name: "string",
+			in:   `"5"`,
+			err:  true,
+		}, {
+			name: "string",
+			in:   `"5s"`,
+			exp:  time.Second * 5,
+		}, {
+			name: "valid",
+			in:   `"1m40s"`,
+			exp:  time.Minute + time.Second * 40,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Delay{}
+			err := d.UnmarshalJSON([]byte(tt.in))
+			if tt.err && err == nil {
+				t.Errorf("expected error: got: %v", d.Duration)
+			}
+			if want, got := tt.exp, d.Duration; want != got {
+				t.Errorf("want: %v, got: %v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will show an error if the duration definition is not valid while parsing the config file instead of silencing it