### PR TITLE
Fix banner

### DIFF
--- a/cmd/mmock/main.go
+++ b/cmd/mmock/main.go
@@ -36,10 +36,8 @@ var ErrNotFoundAnyMock = errors.New("No valid mock config found")
 
 func banner() {
 	fmt.Printf("MMock v %s", VERSION)
-	fmt.Println("")
-
-	fmt.Print(
-		`		.---. .---.
+	fmt.Print(`
+                .---. .---.
                :     : o   :    me want request!
            _..-:   o :     :-.._    /
        .-''  '  ` + "`" + `---' ` + "`" + `---' "   ` + "`" + `` + "`" + `-.


### PR DESCRIPTION
The start of the banner contains 2 tabs while all other rows are prefixed with spaces. This means that the banner is not displayed nicely in some terminals.

![Screenshot 2020-04-14 at 15 59 39](https://user-images.githubusercontent.com/8320753/79233738-8b2efe00-7e69-11ea-9457-92f68eabf208.png)

It bothered me enough to create this PR. I feel like social distancing is getting to me. 🙈