### PR TITLE
Add support for callback (#110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ Mock definition:
 		},
 		"body": "Response body"
 	},
+	"callback": {
+		"method": "GET|POST|PUT|PATCH|...",
+		"url": "http://your-callback/",
+		"delay": "string (response delay in s,ms)",
+		"headers": {
+			"name": ["value"]
+		},
+		"body": "Response body"
+	},
 	"control": {
 		"scenario": {
 			"name": "string (scenario name)",
@@ -220,10 +229,21 @@ Query strings and headers support also global matches (*) in the header/paramete
 
 #### Response (Optional on proxy call)
 
-* *statusCode*: Request http method.
+* *statusCode*: Response status code
 * *headers*: Array of headers. It allows more than one value for the same key and vars.
 * *cookies*: Array of cookies. It allows vars.
 * *body*: Body string. It allows vars.
+
+#### Callback (Optional)
+
+This is used to have mmock make an API request after receiving the mocked request.
+
+* *delay*: Delay before making the callback
+* *url*: URL to make a request to
+* *method*: Request http method
+* *headers*: Array of headers. It allows more than one value for the same key.
+* *body*: Body string. It allows vars.
+* *timeout*: Duration to allow the callback to respond (default 10s)
 
 #### Control (Optional)
 

--- a/config/callback.yaml
+++ b/config/callback.yaml
@@ -1,0 +1,14 @@
+request:
+  method: POST
+  path: "/callback"
+response:
+  statusCode: 202
+  headers:
+    Content-Type:
+    - application/json
+  body: '{}'
+callback:
+  url: https://httpbin.org/post
+  delay: 2s
+  contentType: application/json
+  body: '{"token": "{{request.header.Token}}", "success": true, "response": "{{fake.Digits}}"}'

--- a/config/callback.yaml
+++ b/config/callback.yaml
@@ -8,7 +8,10 @@ response:
     - application/json
   body: '{}'
 callback:
+  method: POST
   url: https://httpbin.org/post
   delay: 2s
-  contentType: application/json
+  headers:
+    Content-Type:
+    - application/json
   body: '{"token": "{{request.header.Token}}", "success": true, "response": "{{fake.Digits}}"}'

--- a/internal/server/dispatcher.go
+++ b/internal/server/dispatcher.go
@@ -69,21 +69,45 @@ func (di Dispatcher) callWebHook(url string, match *match.Transaction) {
 }
 
 func (di *Dispatcher) handleCallback(mRequest *mock.Request, mock *mock.Definition) {
-	url := mock.Callback.Url
-	contentType := mock.Callback.ContentType
+	cb := mock.Callback
 
-	if d := mock.Callback.Delay.Duration; d > 0 {
+	if d := cb.Delay.Duration; d > 0 {
 		log.Printf("Delaying callback by: %s\n", d)
 		time.Sleep(d)
 	}
 
+	url := cb.Url
 	log.Printf("Making callback to %s\n", url)
-	_, err := http.Post(url, contentType, bytes.NewBufferString(mock.Callback.Body))
+	req, err := http.NewRequest(cb.Method, url, bytes.NewBufferString(cb.Body))
 	if err != nil {
-		log.Printf("Error from callback: %s\n", err)
-	} else {
-		log.Println("Callback handled successfully")
+		log.Printf("Error creating callback request: %s\n", err)
+		return
 	}
+	// add headers
+	for h, vs := range cb.Headers {
+		for _, v := range vs {
+			req.Header.Set(h, v)
+		}
+	}
+
+	client := &http.Client{Timeout: time.Second * 10}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("Error making callback: %s\n", err)
+		return
+	}
+	defer resp.Body.Close()
+	statusCode := resp.StatusCode
+	if statusCode >= 400 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Unexpected response from callback. Status code %d", statusCode)
+		} else {
+			log.Printf("Unexpected response from callback. Status code %d, Body %s", statusCode, body)
+		}
+		return
+	}
+	log.Printf("Successfully made callback to %s", url)
 }
 
 //ServerHTTP is the mock http server request handler.

--- a/internal/server/handle_callback.go
+++ b/internal/server/handle_callback.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/jmartin82/mmock/pkg/mock"
+)
+
+// HandleCallback makes a callback required after a request
+func HandleCallback(cb mock.Callback) (*http.Response, error) {
+	if d := cb.Delay.Duration; d > 0 {
+		log.Printf("Delaying callback by: %s\n", d)
+		time.Sleep(d)
+	}
+
+	url := cb.Url
+	log.Printf("Making callback to %s\n", url)
+	req, err := http.NewRequest(cb.Method, url, bytes.NewBufferString(cb.Body))
+	if err != nil {
+		return nil, fmt.Errorf("Error creating HTTP request: %w", err)
+	}
+	// add headers
+	for h, vs := range cb.Headers {
+		for _, v := range vs {
+			req.Header.Set(h, v)
+		}
+	}
+
+	// Default timeout 10s
+	timeout := time.Second * 10
+	if cb.Timeout.Duration > 0 {
+		timeout = cb.Timeout.Duration
+	}
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Error making HTTP request: %w", err)
+	}
+	statusCode := resp.StatusCode
+	if statusCode >= 400 {
+		body, errBody := ioutil.ReadAll(resp.Body)
+		if errBody != nil {
+			// Can't read a body, just log the statusCode
+			err = fmt.Errorf("Unexpected HTTP response. Status code %d", statusCode)
+			return resp, err
+		}
+
+		// Include the response body
+		err = fmt.Errorf("Unexpected HTTP response. Status code %d, Body %s", statusCode, body)
+		return resp, err
+	}
+	return resp, nil
+}

--- a/internal/server/handle_callback_test.go
+++ b/internal/server/handle_callback_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jmartin82/mmock/pkg/mock"
+)
+
+func makeTestServer(allowedMethod string, successResponse string, t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == allowedMethod {
+			t.Logf("Returning 200 %s", successResponse)
+			w.WriteHeader(200)
+			fmt.Fprint(w, successResponse)
+		} else {
+			t.Logf("Returning 405")
+			w.WriteHeader(405)
+			fmt.Fprint(w, "Invalid method")
+		}
+	}))
+}
+
+func TestBadStatusCodeErrors(t *testing.T) {
+	ts := makeTestServer("GET", "response", t)
+	defer ts.Close()
+
+	cb := mock.Callback{
+		Url:    ts.URL,
+		Method: "POST",
+	}
+
+	_, err := HandleCallback(cb)
+	if err == nil {
+		t.Fatalf("Expected error from HandleCallback, got nil")
+	}
+}
+
+func TestPost(t *testing.T) {
+	postResponse := "Post Response"
+	ts := makeTestServer("POST", postResponse, t)
+	defer ts.Close()
+
+	cb := mock.Callback{
+		Url:    ts.URL,
+		Method: "POST",
+		Body:   "Some post body",
+	}
+
+	resp, err := HandleCallback(cb)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Fatalf("Unexpected error from HandleCallback %s", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if string(body) != postResponse {
+		t.Fatalf("Unexpected response body: %s", body)
+	}
+}
+
+func TestGet(t *testing.T) {
+	getResponse := "Get Response"
+	ts := makeTestServer("GET", getResponse, t)
+	defer ts.Close()
+
+	cb := mock.Callback{
+		Url:    ts.URL,
+		Method: "GET",
+	}
+
+	resp, err := HandleCallback(cb)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Fatalf("Unexpected error from HandleCallback %s", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if string(body) != getResponse {
+		t.Fatalf("Unexpected response body: %s", body)
+	}
+}

--- a/pkg/mock/definition.go
+++ b/pkg/mock/definition.go
@@ -39,7 +39,8 @@ type Callback struct {
 	Method string `json:"method"`
 	Url    string `json:"url"`
 	HttpHeaders
-	Body string `json:"body"`
+	Body    string `json:"body"`
+	Timeout Delay  `json:"timeout"`
 }
 
 type Scenario struct {

--- a/pkg/mock/definition.go
+++ b/pkg/mock/definition.go
@@ -34,6 +34,13 @@ type Response struct {
 	Body string `json:"body"`
 }
 
+type Callback struct {
+	Delay       Delay  `json:"delay"`
+	Url         string `json:"url"`
+	ContentType string `json:"contentType"`
+	Body        string `json:"body"`
+}
+
 type Scenario struct {
 	Name          string   `json:"name"`
 	RequiredState []string `json:"requiredState"`
@@ -86,5 +93,6 @@ type Definition struct {
 	Description string   `json:"description"`
 	Request     Request  `json:"request"`
 	Response    Response `json:"response"`
+	Callback    Callback `json:"callback"`
 	Control     Control  `json:"control"`
 }

--- a/pkg/mock/definition.go
+++ b/pkg/mock/definition.go
@@ -35,10 +35,11 @@ type Response struct {
 }
 
 type Callback struct {
-	Delay       Delay  `json:"delay"`
-	Url         string `json:"url"`
-	ContentType string `json:"contentType"`
-	Body        string `json:"body"`
+	Delay  Delay  `json:"delay"`
+	Method string `json:"method"`
+	Url    string `json:"url"`
+	HttpHeaders
+	Body string `json:"body"`
 }
 
 type Scenario struct {

--- a/pkg/vars/evaluator.go
+++ b/pkg/vars/evaluator.go
@@ -26,6 +26,7 @@ func (fp ResponseMessageEvaluator) Eval(req *mock.Request, m *mock.Definition) {
 	fakeFiller := fp.FillerFactory.CreateFakeFiller()
 	streamFiller := fp.FillerFactory.CreateStreamFiller()
 	holders := fp.walkAndGet(m.Response)
+	fp.extractVars(m.Callback.Body, &holders)
 
 	vars := requestFiller.Fill(holders)
 	fp.mergeVars(vars, fakeFiller.Fill(holders))
@@ -63,6 +64,7 @@ func (fp ResponseMessageEvaluator) walkAndFill(m *mock.Definition, vars map[stri
 	}
 
 	res.Body = fp.replaceVars(res.Body, vars)
+	m.Callback.Body = fp.replaceVars(m.Callback.Body, vars)
 }
 
 func (fp ResponseMessageEvaluator) replaceVars(input string, vars map[string][]string) string {

--- a/pkg/vars/evaluator_test.go
+++ b/pkg/vars/evaluator_test.go
@@ -553,3 +553,27 @@ func TestReplaceXmlBodyEncodedTags(t *testing.T) {
 		t.Error("Replaced tags from body form do not match", mock.Response.Body)
 	}
 }
+
+func TestReplaceTagsCallback(t *testing.T) {
+
+	req := mock.Request{}
+	req.Body = "hi!"
+	val := make(mock.Values)
+	val["param1"] = []string{"valParam"}
+	req.QueryStringParameters = val
+
+	cookie := make(mock.Cookies)
+	cookie["cookie1"] = "valCookie"
+	req.Cookies = cookie
+
+	cb := mock.Callback{}
+	cb.Body = "Request Body {{request.body}}. Query {{request.query.param1}}. Cookie: {{request.cookie.cookie1}}. Random: {{fake.UserName}}"
+
+	mock := mock.Definition{Request: req, Callback: cb}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Callback.Body != "Request Body hi!. Query valParam. Cookie: valCookie. Random: AleixMG" {
+		t.Error("Replaced tags in callback body not match", cb.Body)
+	}
+}


### PR DESCRIPTION
This commit adds support for a callback in config. This allows mocking an API which will asynchronously make another API request as part of its contract.

A callback consists of a delay, a URL, a HTTP method, headers and a body. After the Delay, a  request is made to the given URL with the requested method/headers/body. The same substitutions are supported in the callback body as a response body, so eg. request values/fake data can be part of the API call made.

TODO:
- [x] Update README. Figured it'd be best to get some feedback on the code/approach first.