### PR TITLE
Accepts custom JSON compatible content-types when parsing body params

### DIFF
--- a/pkg/vars/request.go
+++ b/pkg/vars/request.go
@@ -173,7 +173,7 @@ func (rp Request) getBodyParam(name string) (string, bool) {
 		return rp.getUrlEncodedFormBodyParam(name)
 	} else if strings.HasPrefix(contentType[0], "application/xml") || strings.HasPrefix(contentType[0], "text/xml") {
 		return rp.getXmlBodyParam(name)
-	} else if strings.HasPrefix(contentType[0], "application/json") {
+	} else if strings.HasPrefix(contentType[0], "application/") && strings.HasSuffix(contentType[0], "json") {
 		return rp.getJsonBodyParam(name)
 	}
 


### PR DESCRIPTION
Parsing request body params doesn't work for custom media types that support JSON like JSON+API spec
```
application/vnd.api+json
```
This change accepts any content type in the form `application/*json`