### PR TITLE
Adding /api/scenarios endpoint to list active scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,11 @@ Like stubbing this call also uses the same DSL to filter and query requests.
 
 ### Scenario
 
+**Title** : Get all active scenarios.<br>
+**URL** : /api/scenarios<br>
+**Method** : GET<br>
+**Response Codes**: Success (200 OK)<br>
+
 **Title** : Clean all scenarios status and pause state.<br>
 **URL** : /api/scenarios/reset_all<br>
 **Method** : GET<br>

--- a/internal/console/dispatcher.go
+++ b/internal/console/dispatcher.go
@@ -89,6 +89,7 @@ func (di *Dispatcher) Start() {
 	e.GET("/api/request/matched", di.requestMatchedHandler)
 	e.GET("/api/request/unmatched", di.requestUnMatchedHandler)
 	e.GET("/api/scenarios/reset_all", di.scenariosResetHandler)
+	e.GET("/api/scenarios", di.scenariosListHandler)
 	e.PUT("/api/scenarios/set/:scenario/:state", di.scenariosSetHandler)
 	e.PUT("/api/scenarios/pause", di.scenariosPauseHandler)
 	e.PUT("/api/scenarios/unpause", di.scenariosUnpauseHandler)
@@ -282,6 +283,11 @@ func (di *Dispatcher) scenariosResetHandler(c echo.Context) error {
 		Result: "reset",
 	}
 	return c.JSON(http.StatusOK, ar)
+}
+
+func (di *Dispatcher) scenariosListHandler(c echo.Context) error {
+	scenarios := di.Scenario.List()
+	return c.String(http.StatusOK, scenarios)
 }
 
 func (di *Dispatcher) scenariosSetHandler(c echo.Context) error {

--- a/pkg/match/scenario_store.go
+++ b/pkg/match/scenario_store.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"encoding/json"
 	"strings"
 )
 
@@ -11,6 +12,7 @@ type ScenearioStorer interface {
 	ResetAll()
 	SetPaused(newstate bool)
 	GetPaused() bool
+	List() string
 }
 
 func NewInMemoryScenarioStore() *InMemoryScenarioStore {
@@ -21,6 +23,11 @@ func NewInMemoryScenarioStore() *InMemoryScenarioStore {
 type InMemoryScenarioStore struct {
 	status map[string]string
 	paused bool
+}
+
+func (sm *InMemoryScenarioStore) List() string {
+	json, _ := json.MarshalIndent(sm.status, "", "  ")
+	return string(json)
 }
 
 func (sm *InMemoryScenarioStore) Reset(name string) bool {


### PR DESCRIPTION
## Summary
Adding a new endpoint to console to display all the active scenarios and their current state

## How to use
- Simply send a GET request to `{{mmock_console_url}}/api/scenarios`. 
- Response is a json representing a list of scenarios along with their current state
- The Json only includes the active (started) scenarios, any scenarios that aren't started yet will not be included in the list

## Demo
https://user-images.githubusercontent.com/57954769/121661777-d9a74f00-caa4-11eb-8052-32ac7d0601c3.mov

