### PR TITLE
Support Regular Expressions for Field Values in JSON Request Body

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A core feature of Mmock is the ability to return canned HTTP responses for reque
 * *queryStringParameters*: Array of query strings. It allows more than one value for the same key.
 * *headers*: Array of headers. It allows more than one value for the same key. **Case sensitive!**
 * *cookies*: Array of cookies.
-* *body*: Body string. It allows * pattern.
+* *body*: Body string. It allows * pattern. It also supports regular expressions for field values within JSON request bodies.
 
 In case of queryStringParameters, headers and cookies, the request can be matched only if all defined keys in mock will be present with the exact or glob value.
 
@@ -280,7 +280,7 @@ You can also use "regex" and "concat" commands to complement GJson query:
 {
   "email": "hilari@sapo.pt",
   "age": 4,
-  "uuid":"0bd74115-2307-458f-8288-b726724045ef",
+  "uuid":"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
   "discarded": "do not return"
 }
 ```
@@ -610,6 +610,7 @@ You can always disable this behavior adding the following flag `-server-statisti
 - Create mapping via console thanks to [@inabajunmr](https://github.com/inabajunmr)
 - Thanks to [@joel-44](https://github.com/joel-44) for bug fixing 
 - Enviroment variables as mock variables thanks to [@marcoreni](https://github.com/marcoreni)
+- Support Regular Expressions for Field Values in JSON Request Body thanks to [@rosspatil](https://github.com/rosspatil)
 
 ### Contributing
 

--- a/pkg/match/payload/json_comparator.go
+++ b/pkg/match/payload/json_comparator.go
@@ -2,7 +2,9 @@ package payload
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
@@ -14,18 +16,51 @@ func isArray(s string) bool {
 	return len(st) > 0 && st[0] == '['
 }
 
-func (js *JSONComparator) doCompare(s1, s2 string, o1, o2 interface{}) bool {
-	var err error
-	err = json.Unmarshal([]byte(s1), &o1)
-	if err != nil {
+func (jc *JSONComparator) doCompareJSONRegex(jsonWithPatterns, jsonWithValues string) bool {
+	var patterns map[string]interface{}
+	var values map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonWithPatterns), &patterns); err != nil {
 		return false
 	}
-	err = json.Unmarshal([]byte(s2), &o2)
-	if err != nil {
+	if err := json.Unmarshal([]byte(jsonWithValues), &values); err != nil {
 		return false
 	}
+	return match(patterns, values)
+}
 
-	return reflect.DeepEqual(o1, o2)
+func (jc *JSONComparator) doCompareArrayRegex(jsonWithPatterns, jsonWithValues string) bool {
+	var patterns []map[string]interface{}
+	var values []map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonWithPatterns), &patterns); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(jsonWithValues), &values); err != nil {
+		return false
+	}
+	for i := 0; i < len(patterns); i++ {
+		if !match(patterns[i], values[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func match(p, v map[string]interface{}) bool {
+	for field, pattern := range p {
+		value, exists := v[field]
+		if !exists {
+			return false
+		}
+		str, ok := pattern.(string)
+		if !ok {
+			return reflect.DeepEqual(pattern, value)
+		}
+		matched, err := regexp.MatchString(str, fmt.Sprint(value))
+		if err != nil || !matched {
+			return false
+		}
+	}
+	return true
 }
 
 func (jc *JSONComparator) Compare(s1, s2 string) bool {
@@ -35,13 +70,8 @@ func (jc *JSONComparator) Compare(s1, s2 string) bool {
 	}
 
 	if isArray(s1) || isArray(s2) {
-		var o1 []interface{}
-		var o2 []interface{}
-		return jc.doCompare(s1, s2, o1, o2)
+		return jc.doCompareArrayRegex(s1, s2)
 	}
 
-	var o1 interface{}
-	var o2 interface{}
-
-	return jc.doCompare(s1, s2, o1, o2)
+	return jc.doCompareJSONRegex(s1, s2)
 }

--- a/pkg/match/payload/json_comparator_test.go
+++ b/pkg/match/payload/json_comparator_test.go
@@ -13,6 +13,7 @@ func TestJSONComparator_Compare(t *testing.T) {
 		want bool
 	}{
 		{"Test same value order and format", args{"{\"name\":\"bob\",\"age\":30}", "{\"name\":\"bob\",\"age\":30}"}, true},
+		{"Test same value order and format in regex", args{"{\"name\":\"b.*\",\"age\":30}", "{\"name\":\"bob\",\"age\":30}"}, true},
 		{"Test different order", args{"{\"name\":\"bob\",\"age\":30}", "{\"age\":30,\"name\":\"bob\"}"}, true},
 		{"Test equal arrays", args{"[{\"name\":\"bob\",\"age\":30}]", "[{\"age\":30,\"name\":\"bob\"}]"}, true},
 		{"Test object and array difference", args{"{\"name\":\"bob\",\"age\":30}", "[{\"age\":30,\"name\":\"bob\"}]"}, false},


### PR DESCRIPTION
Resolves #150 


This feature request proposes the addition of support for using regular expressions to validate and match field values within JSON request bodies. This enhancement aims to provide more flexibility and power in handling JSON requests, especially in scenarios requiring complex validation rules or pattern matching.

In many applications, especially those involving data validation and filtering, the need to use regular expressions for field values is common. Regular expressions provide a robust and flexible method for pattern matching, which can greatly enhance the application's ability to process and validate complex data structures. Adding support for regular expressions in JSON request bodies would enable developers to define more sophisticated validation rules and data processing logic directly within their JSON schemas or request handlers.

### Use Cases

- **Data Validation:** Allow developers to specify regex patterns for data validation directly in the JSON schema, enabling more complex validation rules beyond basic data types and lengths.
- **Dynamic Filtering:** Support dynamic data filtering in APIs by allowing regex patterns in request bodies, making it easier to query datasets with complex search criteria specially in the cases where UUID are available in the request body.
- **Routing Logic:** Enhance API routing logic by using regex patterns to match and direct requests based on complex rules defined in the JSON payload.

There are enormous use cases I have handled with this feature. 

I welcome feedback on this proposal, including concerns about performance, and ease of use. Additionally, I am interested in hearing about potential alternatives or enhancements to this approach.