### PR TITLE
Fix prefix in path parameter issue

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -46,7 +46,7 @@ func NewRoute(pattern string) *Route {
 }
 
 func pathToRegex(path string) (*regexp.Regexp, []string) {
-	pattern, _ := regexp.Compile("\\/:([A-Za-z0-9]+)")
+	pattern, _ := regexp.Compile(`:([A-Za-z0-9]+)`)
 	matches := pattern.FindAllStringSubmatch(path, -1)
 	keys := []string{}
 
@@ -56,7 +56,7 @@ func pathToRegex(path string) (*regexp.Regexp, []string) {
 
 	str := fmt.Sprintf("^%s\\/?$", strings.Replace(path, "/", "\\/", -1))
 
-	str = pattern.ReplaceAllString(str, "/([^\\/]+)")
+	str = pattern.ReplaceAllString(str, "([^\\/]+)")
 	str = strings.Replace(str, ".", "\\.", -1)
 
 	regex, _ := regexp.Compile(str)

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -36,6 +36,9 @@ func TestParams(t *testing.T) {
 	route = NewRoute("/fruits/:fruit/:page")
 	equal(t, route.Match("/fruits/cherry/452").Params["fruit"], "cherry")
 	equal(t, route.Match("/fruits/cherry/452").Params["page"], "452")
+
+	route = NewRoute("/fruits/prefix-:fruit")
+	equal(t, route.Match("/fruits/prefix-cherry").Params["fruit"], "cherry")
 }
 
 func equal(t *testing.T, a string, b string) {


### PR DESCRIPTION
Hi Jordi,

After upgrading from `v3.0.1` to `v3.1.6` path parameters with prefixes (i.e.: `/fruits/prefix-:fruit`) stopped working.

Here is a fix for this situation.

Thank you