### PR TITLE
suppress ErrPathNotMatch messages

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -64,7 +64,7 @@ func (rr *Router) Resolve(req *mock.Request) (*mock.Definition, *match.Result) {
 			return &md, mLog
 		}
 		mLog.Errors = append(mLog.Errors, match.Error{URI: m.URI, Reason: err.Error()})
-		if ! errors.Is(err, match.ErrPathNotMatch) {
+		if !errors.Is(err, match.ErrPathNotMatch) {
 			log.Printf("Discarding mock: %s Reason: %s\n", m.URI, err.Error())
 		}
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/gob"
+	"errors"
 
 	"log"
 
@@ -63,7 +64,7 @@ func (rr *Router) Resolve(req *mock.Request) (*mock.Definition, *match.Result) {
 			return &md, mLog
 		}
 		mLog.Errors = append(mLog.Errors, match.Error{URI: m.URI, Reason: err.Error()})
-		if err != match.ErrPathNotMatch {
+		if ! errors.Is(err, match.ErrPathNotMatch) {
 			log.Printf("Discarding mock: %s Reason: %s\n", m.URI, err.Error())
 		}
 	}

--- a/pkg/match/request.go
+++ b/pkg/match/request.go
@@ -153,7 +153,7 @@ func (mm Request) Match(req *mock.Request, mock *mock.Definition, scenarioAware 
 	}
 
 	if !glob.Glob(mock.Request.Path, req.Path) && route.Match(req.Path) == nil {
-		return false, fmt.Errorf("Path not match. Actual: %s, Expected: %s", req.Path, mock.Request.Path)
+		return false, fmt.Errorf("%w Actual: %s, Expected: %s", ErrPathNotMatch, req.Path, mock.Request.Path)
 	}
 
 	if !mm.mockIncludesMethod(req.Method, &mock.Request) {


### PR DESCRIPTION
It looks like the intention was to supress ErrPathNotMatch messages from being logged. 
This PR makes that happen.