### PR TITLE
Fixed typo request.authority in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ You can use variable data in response. The variables will be defined as tags lik
  - request.cookie."*key*"
  - request.fragment
  - request.url (full url with scheme, hostname, port, path and query parameters)
- - request.autority (return scheme, hostname and port (optional))
+ - request.authority (return scheme, hostname and port (optional))
  - request.body
 
 You can extract information from the request body too, using a dot notation path:


### PR DESCRIPTION
Hi,
I have raised a PR to fix a typo on the README section to display scheme, hostname and port.
Thank you.