### PR TITLE
Bump Docker base image to Alpine Linux 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.20
 
 RUN apk --no-cache add \
     ca-certificates curl
@@ -16,4 +16,4 @@ EXPOSE 8082 8083 8084
 
 ENTRYPOINT ["mmock","-config-path","/config","-tls-path","/tls"]
 CMD ["-server-ip","0.0.0.0","-console-ip","0.0.0.0"]
-HEALTHCHECK --interval=30s --timeout=3s --start-period=3s --retries=2 CMD curl -f http://localhost:8082 || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --start-period=3s --retries=2 CMD curl -fsS http://localhost:8082 || exit 1


### PR DESCRIPTION
Bump Docker base image to [Alpine Linux](https://hub.docker.com/_/alpine) 3.20 and make health check less verbose by adding `--silent --show-error` to the cURL command.

<details>
<summary>`docker scout cves` output before</summary>

```text
❯ docker scout cves jordimartin/mmock
    i New version 1.12.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
          ✓ SBOM of image already cached, 49 packages indexed
    ✗ Detected 2 vulnerable packages with a total of 11 vulnerabilities


## Overview

                    │           Analyzed Image            
────────────────────┼─────────────────────────────────────
  Target            │  jordimartin/mmock:latest           
    digest          │  bd8a572b79c7                       
    platform        │ linux/arm64                         
    vulnerabilities │    1C     2H     3M     0L     6?   
    size            │ 10 MB                               
    packages        │ 49                                  


## Packages and Vulnerabilities

   1C     2H     2M     0L     6?  stdlib 1.21.4
pkg:golang/stdlib@1.21.4

    ✗ CRITICAL CVE-2024-24790
      https://scout.docker.com/v/CVE-2024-24790
      Affected range : <1.21.11  
      Fixed version  : 1.21.11   
    
    ✗ HIGH CVE-2024-24791
      https://scout.docker.com/v/CVE-2024-24791
      Affected range : <1.21.12  
      Fixed version  : 1.21.12   
    
    ✗ HIGH CVE-2023-45283
      https://scout.docker.com/v/CVE-2023-45283
      Affected range : >=1.21.4  
                     : <1.21.5   
      Fixed version  : 1.21.5    
    
    ✗ MEDIUM CVE-2024-24789
      https://scout.docker.com/v/CVE-2024-24789
      Affected range : <1.21.11  
      Fixed version  : 1.21.11   
    
    ✗ MEDIUM CVE-2023-39326
      https://scout.docker.com/v/CVE-2023-39326
      Affected range : >=1.21.0-0  
                     : <1.21.5     
      Fixed version  : 1.21.5      
    
    ✗ UNSPECIFIED CVE-2024-24785
      https://scout.docker.com/v/CVE-2024-24785
      Affected range : <1.21.8  
      Fixed version  : 1.21.8   
    
    ✗ UNSPECIFIED CVE-2024-24784
      https://scout.docker.com/v/CVE-2024-24784
      Affected range : <1.21.8  
      Fixed version  : 1.21.8   
    
    ✗ UNSPECIFIED CVE-2024-24783
      https://scout.docker.com/v/CVE-2024-24783
      Affected range : <1.21.8  
      Fixed version  : 1.21.8   
    
    ✗ UNSPECIFIED CVE-2023-45290
      https://scout.docker.com/v/CVE-2023-45290
      Affected range : <1.21.8  
      Fixed version  : 1.21.8   
    
    ✗ UNSPECIFIED CVE-2023-45289
      https://scout.docker.com/v/CVE-2023-45289
      Affected range : <1.21.8  
      Fixed version  : 1.21.8   
    
    ✗ UNSPECIFIED CVE-2023-45288
      https://scout.docker.com/v/CVE-2023-45288
      Affected range : <1.21.9  
      Fixed version  : 1.21.9   
    

   0C     0H     1M     0L  golang.org/x/net 0.19.0
pkg:golang/golang.org/x/net@0.19.0

    ✗ MEDIUM CVE-2023-45288 [Uncontrolled Resource Consumption]
      https://scout.docker.com/v/CVE-2023-45288
      Affected range : <0.23.0                                       
      Fixed version  : 0.23.0                                        
      CVSS Score     : 5.3                                           
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L  
    


12 vulnerabilities found in 2 packages
  UNSPECIFIED  6  
  LOW          0  
  MEDIUM       3  
  HIGH         2  
  CRITICAL     1
```
</details>

<details>
<summary>`docker scout cves` output after</summary>

```text
❯ docker scout cves mmock
    i New version 1.12.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
    ✓ Image stored for indexing
    ✓ Indexed 59 packages
    ✓ Provenance obtained from attestation
    ✓ No vulnerable package detected


## Overview

                    │               Analyzed Image                
────────────────────┼─────────────────────────────────────────────
  Target            │  mmock:latest                               
    digest          │  9b1f6702fa5e                               
    platform        │ linux/arm64/v8                              
    provenance      │ git@github.com:jmartin82/mmock.git          
                    │  19a2f165d7bc596c52d654bf957e862bcdb6549f   
    vulnerabilities │    0C     0H     0M     0L                  
    size            │ 14 MB                                       
    packages        │ 59                                          


## Packages and Vulnerabilities

  No vulnerable packages detected
```
</summary>