### PR TITLE
Add content sniffing for request bodies to automatically detect JSON or XML when the Content-Type header is missing.

### DIFF
--- a/cmd/mmock/main.go
+++ b/cmd/mmock/main.go
@@ -121,17 +121,17 @@ func getVarsProcessor() *vars.ResponseMessageEvaluator {
 
 func startServer(ip string, port, portTLS int, configTLS, tlsKeyPassword string, done chan struct{}, router server.RequestResolver, mLog chan match.Transaction, scenario match.ScenearioStorer, varsProcessor vars.Evaluator, spier match.TransactionSpier) {
 	dispatcher := server.Dispatcher{
-		IP:            ip,
-		Port:          port,
-		PortTLS:       portTLS,
-		ConfigTLS:     configTLS,
+		IP:             ip,
+		Port:           port,
+		PortTLS:        portTLS,
+		ConfigTLS:      configTLS,
 		TLSKeyPassword: tlsKeyPassword,
-		Resolver:      router,
-		Translator:    mock.HTTP{},
-		Evaluator:     varsProcessor,
-		Scenario:      scenario,
-		Spier:         spier,
-		Mlog:          mLog,
+		Resolver:       router,
+		Translator:     mock.HTTP{},
+		Evaluator:      varsProcessor,
+		Scenario:       scenario,
+		Spier:          spier,
+		Mlog:           mLog,
 	}
 	dispatcher.Start()
 	done <- struct{}{}

--- a/internal/server/dispatcher.go
+++ b/internal/server/dispatcher.go
@@ -30,17 +30,17 @@ var log = logger.Log
 
 // Dispatcher is the mock http server
 type Dispatcher struct {
-	IP            string
-	Port          int
-	PortTLS       int
-	ConfigTLS     string
+	IP             string
+	Port           int
+	PortTLS        int
+	ConfigTLS      string
 	TLSKeyPassword string
-	Resolver      RequestResolver
-	Translator    mock.MessageTranslator
-	Evaluator     vars.Evaluator
-	Scenario      match.ScenearioStorer
-	Spier         match.TransactionSpier
-	Mlog          chan match.Transaction
+	Resolver       RequestResolver
+	Translator     mock.MessageTranslator
+	Evaluator      vars.Evaluator
+	Scenario       match.ScenearioStorer
+	Spier          match.TransactionSpier
+	Mlog           chan match.Transaction
 }
 
 func (di Dispatcher) recordMatchData(msg match.Transaction) {

--- a/internal/server/dispatcher_gzip_test.go
+++ b/internal/server/dispatcher_gzip_test.go
@@ -57,14 +57,14 @@ func (mr *mockResolver) Resolve(req *mock.Request) (*mock.Definition, *match.Res
 // mockSpier does nothing for testing
 type mockSpier struct{}
 
-func (ms *mockSpier) Save(t match.Transaction)                           {}
-func (ms *mockSpier) Reset()                                             {}
-func (ms *mockSpier) ResetMatch(r mock.Request)                          {}
-func (ms *mockSpier) GetAll() []match.Transaction                        { return nil }
-func (ms *mockSpier) Get(limit int, offset int) []match.Transaction      { return nil }
-func (ms *mockSpier) Find(r mock.Request) []match.Transaction            { return nil }
-func (ms *mockSpier) GetMatched() []match.Transaction                    { return nil }
-func (ms *mockSpier) GetUnMatched() []match.Transaction                  { return nil }
+func (ms *mockSpier) Save(t match.Transaction)                      {}
+func (ms *mockSpier) Reset()                                        {}
+func (ms *mockSpier) ResetMatch(r mock.Request)                     {}
+func (ms *mockSpier) GetAll() []match.Transaction                   { return nil }
+func (ms *mockSpier) Get(limit int, offset int) []match.Transaction { return nil }
+func (ms *mockSpier) Find(r mock.Request) []match.Transaction       { return nil }
+func (ms *mockSpier) GetMatched() []match.Transaction               { return nil }
+func (ms *mockSpier) GetUnMatched() []match.Transaction             { return nil }
 
 // mockEvaluator does nothing for testing
 type mockEvaluator struct{}

--- a/internal/server/dispatcher_test.go
+++ b/internal/server/dispatcher_test.go
@@ -42,7 +42,7 @@ func TestLoadKeyPair_EncryptedKey(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	password := "testpassword123"
-	
+
 	// Generate test certificate and encrypted key
 	certFile, keyFile := generateTestCertificate(t, tmpDir, password)
 
@@ -87,11 +87,11 @@ func generateTestCertificate(t *testing.T, dir, password string) (certFile, keyF
 			StreetAddress: []string{""},
 			PostalCode:    []string{""},
 		},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses:  nil,
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: nil,
 	}
 
 	// Create certificate

--- a/pkg/match/payload/comparator.go
+++ b/pkg/match/payload/comparator.go
@@ -26,6 +26,12 @@ func NewDefaultComparator() *Comparator {
 	comparator.AddComparer("application/merge-patch+json", json)
 	comparator.AddComparer("application/xml", xml)
 	comparator.AddComparer("text/xml", xml)
+
+	// Register content type sniffer for generic binary types
+	cts := NewContentTypeSniffer()
+	comparator.AddComparer("application/octet-stream", cts)
+	comparator.AddComparer("application/binary", cts)
+
 	return comparator
 }
 
@@ -41,4 +47,77 @@ func (c Comparator) Compare(contentType, s1, s2 string) (comparable bool, equals
 	}
 
 	return true, comparer.Compare(s1, s2)
+}
+
+// SniffContentType detects the content type by inspecting the first non-whitespace character of the body.
+func SniffContentType(body string) string {
+	trimmedBody := strings.TrimLeft(body, " \t\r\n")
+	if len(trimmedBody) > 0 {
+		switch trimmedBody[0] {
+		case '{', '[':
+			return "application/json"
+		case '<':
+			return "application/xml"
+		}
+	}
+	return ""
+}
+
+// ContentTypeSniffer implements Comparer by sniffing the body to detect its real type
+// and delegating to the appropriate comparer.
+type ContentTypeSniffer struct {
+	comparers map[string]Comparer
+}
+
+func NewContentTypeSniffer() *ContentTypeSniffer {
+	return &ContentTypeSniffer{
+		comparers: map[string]Comparer{
+			"application/json": &JSONComparator{},
+			"application/xml":  &XMLComparator{},
+		},
+	}
+}
+
+func (cts *ContentTypeSniffer) Compare(s1, s2 string) bool {
+	trimmed := strings.TrimLeft(s2, " \t\r\n")
+	ct := SniffContentType(trimmed)
+	if c, ok := cts.comparers[ct]; ok {
+		return c.Compare(s1, trimmed)
+	}
+	return s1 == s2
+}
+
+// DetectedContentType returns the content type from headers, falling back to body sniffing if missing or generic.
+func (cts *ContentTypeSniffer) DetectedContentType(headers map[string][]string, body string) string {
+	if headers != nil {
+		if ct, found := headers["Content-Type"]; found && len(ct) > 0 {
+			val := ct[0]
+			// For generic binary types, sniff the actual content
+			if strings.HasPrefix(val, "application/octet-stream") || strings.HasPrefix(val, "application/binary") {
+				if sniffed := SniffContentType(body); sniffed != "" {
+					return sniffed
+				}
+			}
+			return val
+		}
+	}
+	return SniffContentType(body)
+}
+
+// IsJSON returns true if the detected content type is JSON.
+func (cts *ContentTypeSniffer) IsJSON(headers map[string][]string, body string) bool {
+	ct := cts.DetectedContentType(headers, body)
+	return strings.HasPrefix(ct, "application/") && strings.HasSuffix(ct, "json")
+}
+
+// IsXML returns true if the detected content type is XML.
+func (cts *ContentTypeSniffer) IsXML(headers map[string][]string, body string) bool {
+	ct := cts.DetectedContentType(headers, body)
+	return strings.HasPrefix(ct, "application/xml") || strings.HasPrefix(ct, "text/xml")
+}
+
+// IsFormEncoded returns true if the detected content type is x-www-form-urlencoded.
+func (cts *ContentTypeSniffer) IsFormEncoded(headers map[string][]string, body string) bool {
+	ct := cts.DetectedContentType(headers, body)
+	return strings.HasPrefix(ct, "application/x-www-form-urlencoded")
 }

--- a/pkg/match/payload/comparator.go
+++ b/pkg/match/payload/comparator.go
@@ -87,27 +87,36 @@ func (cts *ContentTypeSniffer) Compare(s1, s2 string) bool {
 	return s1 == s2
 }
 
-// DetectedContentType returns the content type from headers, falling back to body sniffing if missing or generic.
+// isKnownContentType reports whether ct names a payload type mmock can parse directly.
+func isKnownContentType(ct string) bool {
+	return (strings.HasPrefix(ct, "application/") && strings.Contains(ct, "json")) ||
+		strings.HasPrefix(ct, "application/xml") ||
+		strings.HasPrefix(ct, "text/xml") ||
+		strings.HasPrefix(ct, "application/x-www-form-urlencoded")
+}
+
+// DetectedContentType returns the content type from headers, falling back to body
+// sniffing when the header is missing or names a type we cannot parse (e.g.
+// application/octet-stream, or a legacy client reporting a wrong type like application/text).
 func (cts *ContentTypeSniffer) DetectedContentType(headers map[string][]string, body string) string {
+	ct := ""
 	if headers != nil {
-		if ct, found := headers["Content-Type"]; found && len(ct) > 0 {
-			val := ct[0]
-			// For generic binary types, sniff the actual content
-			if strings.HasPrefix(val, "application/octet-stream") || strings.HasPrefix(val, "application/binary") {
-				if sniffed := SniffContentType(body); sniffed != "" {
-					return sniffed
-				}
-			}
-			return val
+		if h, found := headers["Content-Type"]; found && len(h) > 0 {
+			ct = strings.TrimSpace(strings.Split(h[0], ";")[0])
 		}
 	}
-	return SniffContentType(body)
+	if ct == "" || !isKnownContentType(ct) {
+		if sniffed := SniffContentType(body); sniffed != "" {
+			return sniffed
+		}
+	}
+	return ct
 }
 
 // IsJSON returns true if the detected content type is JSON.
 func (cts *ContentTypeSniffer) IsJSON(headers map[string][]string, body string) bool {
 	ct := cts.DetectedContentType(headers, body)
-	return strings.HasPrefix(ct, "application/") && strings.HasSuffix(ct, "json")
+	return strings.HasPrefix(ct, "application/") && strings.Contains(ct, "json")
 }
 
 // IsXML returns true if the detected content type is XML.

--- a/pkg/match/payload/comparator_test.go
+++ b/pkg/match/payload/comparator_test.go
@@ -49,6 +49,8 @@ func TestComparatorDefaultFactory(t *testing.T) {
 		"application/merge-patch+json",
 		"application/xml",
 		"text/xml",
+		"application/octet-stream",
+		"application/binary",
 	}
 
 	for _, comparer := range comparers {

--- a/pkg/match/payload/comparator_test.go
+++ b/pkg/match/payload/comparator_test.go
@@ -40,6 +40,70 @@ func TestComparator_Compare(t *testing.T) {
 	}
 }
 
+func TestContentTypeSniffer_DetectedContentType(t *testing.T) {
+	jsonBody := `{"name":"bob"}`
+	xmlBody := `<root><name>bob</name></root>`
+
+	tests := []struct {
+		name    string
+		headers map[string][]string
+		body    string
+		want    string
+	}{
+		{"missing header, json body", nil, jsonBody, "application/json"},
+		{"missing header, xml body", map[string][]string{}, xmlBody, "application/xml"},
+		{"json header trusted", map[string][]string{"Content-Type": {"application/json"}}, jsonBody, "application/json"},
+		{"json header with charset stripped", map[string][]string{"Content-Type": {"application/json; charset=utf-8"}}, jsonBody, "application/json"},
+		{"aws json header trusted", map[string][]string{"Content-Type": {"application/x-amz-json-1.1"}}, jsonBody, "application/x-amz-json-1.1"},
+		{"octet-stream sniffed to json", map[string][]string{"Content-Type": {"application/octet-stream"}}, jsonBody, "application/json"},
+		{"binary sniffed to xml", map[string][]string{"Content-Type": {"application/binary"}}, xmlBody, "application/xml"},
+		{"wrong type application/text sniffed to json", map[string][]string{"Content-Type": {"application/text"}}, jsonBody, "application/json"},
+		{"wrong type text/plain sniffed to xml", map[string][]string{"Content-Type": {"text/plain"}}, xmlBody, "application/xml"},
+		{"wrong type with unstructured body keeps header", map[string][]string{"Content-Type": {"application/text"}}, "hello", "application/text"},
+	}
+
+	cts := NewContentTypeSniffer()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cts.DetectedContentType(tt.headers, tt.body); got != tt.want {
+				t.Errorf("DetectedContentType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentTypeSniffer_IsJSON(t *testing.T) {
+	jsonBody := `{"name":"bob"}`
+	xmlBody := `<root><name>bob</name></root>`
+
+	tests := []struct {
+		name    string
+		headers map[string][]string
+		body    string
+		want    bool
+	}{
+		{"application/json", map[string][]string{"Content-Type": {"application/json"}}, jsonBody, true},
+		{"application/ld+json", map[string][]string{"Content-Type": {"application/ld+json"}}, jsonBody, true},
+		{"application/json with charset", map[string][]string{"Content-Type": {"application/json; charset=utf-8"}}, jsonBody, true},
+		{"application/x-amz-json-1.1", map[string][]string{"Content-Type": {"application/x-amz-json-1.1"}}, jsonBody, true},
+		{"missing header json body", nil, jsonBody, true},
+		{"octet-stream json body", map[string][]string{"Content-Type": {"application/octet-stream"}}, jsonBody, true},
+		{"wrong type application/text json body", map[string][]string{"Content-Type": {"application/text"}}, jsonBody, true},
+		{"application/xml", map[string][]string{"Content-Type": {"application/xml"}}, xmlBody, false},
+		{"wrong type text/plain xml body", map[string][]string{"Content-Type": {"text/plain"}}, xmlBody, false},
+		{"application/text unstructured body", map[string][]string{"Content-Type": {"application/text"}}, "hello", false},
+	}
+
+	cts := NewContentTypeSniffer()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cts.IsJSON(tt.headers, tt.body); got != tt.want {
+				t.Errorf("IsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestComparatorDefaultFactory(t *testing.T) {
 	c := NewDefaultComparator()
 

--- a/pkg/match/request.go
+++ b/pkg/match/request.go
@@ -233,8 +233,18 @@ func (mm Request) bodyMatch(mockReq mock.Request, req *mock.Request) bool {
 		return true
 	}
 
-	if value, ok := req.Headers["Content-Type"]; ok && len(value) > 0 {
-		if comparable, ok := mm.comparator.Compare(value[0], mockReq.Body, req.Body); comparable {
+	// Check if we should use a specific comparator based on Content-Type
+	if mm.comparator != nil {
+		ct := ""
+		body := req.Body
+		if h, ok := req.Headers["Content-Type"]; ok && len(h) > 0 {
+			ct = h[0]
+		} else {
+			body = strings.TrimLeft(req.Body, " \t\r\n")
+			ct = payload.SniffContentType(body)
+		}
+
+		if comparable, ok := mm.comparator.Compare(ct, mockReq.Body, body); comparable {
 			return ok
 		}
 	}

--- a/pkg/match/request.go
+++ b/pkg/match/request.go
@@ -247,6 +247,14 @@ func (mm Request) bodyMatch(mockReq mock.Request, req *mock.Request) bool {
 		if comparable, ok := mm.comparator.Compare(ct, mockReq.Body, body); comparable {
 			return ok
 		}
+
+		// Fallback: ct came from header but has no registered comparator — try sniffing the body
+		sniffedBody := strings.TrimLeft(req.Body, " \t\r\n")
+		if sniffedCT := payload.SniffContentType(sniffedBody); sniffedCT != "" && sniffedCT != ct {
+			if comparable, ok := mm.comparator.Compare(sniffedCT, mockReq.Body, sniffedBody); comparable {
+				return ok
+			}
+		}
 	}
 
 	return false

--- a/pkg/match/request_test.go
+++ b/pkg/match/request_test.go
@@ -609,6 +609,31 @@ func TestMatchIgnoreUnexpectedHeadersAndQuery(t *testing.T) {
 	}
 }
 
+func TestBodyComparatorSniffFallback(t *testing.T) {
+	// AWS SDK sends application/x-amz-json-1.1 which is not registered in the comparator.
+	// The fallback should sniff the body as application/json and use JSONComparator.
+	req := mock.Request{}
+	req.Body = `{"Database":"mydb","TableName":"events"}`
+	req.Headers = make(mock.Values)
+	req.Headers["Content-Type"] = []string{"application/x-amz-json-1.1"}
+
+	m := mock.Definition{}
+	m.Request.Body = `{"Database": "mydb", "TableName": "events"}`
+
+	comparator := payload.NewDefaultComparator()
+	mm := Request{comparator: comparator}
+
+	if b, err := mm.Match(&req, &m, true); !b {
+		t.Errorf("Expected JSON match via sniff fallback for application/x-amz-json-1.1. Err: %v", err)
+	}
+
+	// Mismatched JSON should not match
+	req.Body = `{"Database":"mydb","TableName":"other_table"}`
+	if b, _ := mm.Match(&req, &m, true); b {
+		t.Error("Should NOT match different JSON payload")
+	}
+}
+
 func TestMatchBodySniffing(t *testing.T) {
 	// Scenario 1: JSON Object with whitespace and NO Content-Type header
 	req := mock.Request{}

--- a/pkg/vars/evaluator.go
+++ b/pkg/vars/evaluator.go
@@ -9,6 +9,11 @@ import (
 
 var varsRegex = regexp.MustCompile(`\{\{\s*(.+?)\s*\}\}`)
 
+// streamStartRegex matches only the opening of a stream tag. The whole tag is then
+// delimited by a parenthesis-depth scan (findStreamSpan) instead of a regex, so the
+// argument may contain nested {{...}} holders and gjson parentheses/braces.
+var streamStartRegex = regexp.MustCompile(`\{\{\s*(?:file|http)\.contents\(`)
+
 type Evaluator interface {
 	Eval(req *mock.Request, m *mock.Definition)
 }
@@ -24,12 +29,12 @@ func NewResponseMessageEvaluator(fp FillerFactory) *ResponseMessageEvaluator {
 func (fp ResponseMessageEvaluator) Eval(req *mock.Request, m *mock.Definition) {
 	requestFiller := fp.FillerFactory.CreateRequestFiller(req, m)
 	fakeFiller := fp.FillerFactory.CreateFakeFiller()
-	streamFiller := fp.FillerFactory.CreateStreamFiller()
+	streamFiller := fp.FillerFactory.CreateStreamFiller(req, m)
 
 	//first replace the external streams
-	holders := fp.walkAndGet(m.Response.HTTPEntity)
+	holders := fp.walkAndGetStreams(m.Response.HTTPEntity)
 	vars := streamFiller.Fill(holders)
-	fp.walkAndFill(&m.Response.HTTPEntity, vars)
+	fp.walkAndFillStreams(&m.Response.HTTPEntity, vars)
 
 	//repeat the same opration in order to replace any holder coming from the external streams
 
@@ -104,4 +109,114 @@ func (fp ResponseMessageEvaluator) mergeVars(org map[string][]string, vals map[s
 	for k, v := range vals {
 		org[k] = v
 	}
+}
+
+// walkAndGetStreams collects the inner content of every whole stream tag
+// ({{ file.contents(...) }} / {{ http.contents(...) }}) found in the entity, using
+// findStreamSpan so arguments containing nested {{...}} holders are captured intact.
+func (fp ResponseMessageEvaluator) walkAndGetStreams(res mock.HTTPEntity) []string {
+	vars := []string{}
+	for _, header := range res.Headers {
+		for _, value := range header {
+			vars = append(vars, extractStreamTags(value)...)
+		}
+	}
+	for _, value := range res.Cookies {
+		vars = append(vars, extractStreamTags(value)...)
+	}
+	vars = append(vars, extractStreamTags(res.Body)...)
+	return vars
+}
+
+// walkAndFillStreams replaces every whole stream tag with its resolved value.
+func (fp ResponseMessageEvaluator) walkAndFillStreams(res *mock.HTTPEntity, vars map[string][]string) {
+	for header, values := range res.Headers {
+		for i, value := range values {
+			res.Headers[header][i] = replaceStreamTags(value, vars)
+		}
+	}
+	for cookie, value := range res.Cookies {
+		res.Cookies[cookie] = replaceStreamTags(value, vars)
+	}
+	res.Body = replaceStreamTags(res.Body, vars)
+}
+
+// findStreamSpan locates the next whole stream tag at or after `from`, returning the
+// byte offsets of the whole {{ ... }} span and the trimmed inner content (e.g.
+// "file.contents(...)"). Unlike varsRegex, it tolerates nested {{...}} holders and
+// gjson parentheses/braces by scanning for the balanced closing ')' of contents(...)
+// before requiring the closing '}}'. Malformed openings are skipped.
+func findStreamSpan(s string, from int) (start, end int, inner string, ok bool) {
+	for from < len(s) {
+		loc := streamStartRegex.FindStringIndex(s[from:])
+		if loc == nil {
+			return 0, 0, "", false
+		}
+		start = from + loc[0]
+		openParen := from + loc[1] // index just after the '(' of contents(
+
+		depth := 1
+		i := openParen
+		for ; i < len(s); i++ {
+			if s[i] == '(' {
+				depth++
+			} else if s[i] == ')' {
+				depth--
+				if depth == 0 {
+					break
+				}
+			}
+		}
+
+		if depth == 0 {
+			j := i + 1
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\r' || s[j] == '\n') {
+				j++
+			}
+			if j+1 < len(s) && s[j] == '}' && s[j+1] == '}' {
+				return start, j + 2, strings.TrimSpace(s[start+2 : i+1]), true
+			}
+		}
+
+		from = openParen // malformed opening: skip past it and keep searching
+	}
+	return 0, 0, "", false
+}
+
+// extractStreamTags returns the inner content of every whole stream tag in input.
+func extractStreamTags(input string) []string {
+	tags := []string{}
+	for from := 0; ; {
+		_, end, inner, ok := findStreamSpan(input, from)
+		if !ok {
+			break
+		}
+		tags = append(tags, inner)
+		from = end
+	}
+	return tags
+}
+
+// replaceStreamTags substitutes each whole stream tag with the first unused value from
+// vars keyed by the tag's inner content, leaving unresolved tags verbatim. It uses the
+// same one-shot per-value semantics as replaceVars.
+func replaceStreamTags(input string, vars map[string][]string) string {
+	var b strings.Builder
+	from := 0
+	for {
+		start, end, inner, ok := findStreamSpan(input, from)
+		if !ok {
+			break
+		}
+		b.WriteString(input[from:start])
+		if v, found := vars[inner]; found && len(v) > 0 {
+			b.WriteString(v[0])
+			vars[inner] = v[1:]
+		} else {
+			b.WriteString(input[start:end])
+		}
+		from = end
+	}
+	b.WriteString(input[from:])
+	return b.String()
 }

--- a/pkg/vars/evaluator_test.go
+++ b/pkg/vars/evaluator_test.go
@@ -632,3 +632,67 @@ func TestReplaceBigFile(t *testing.T) {
 		t.Error("Replaced tags in a external stream doesn't work.", res.Body, mock.Response.Body)
 	}
 }
+
+func TestEvalFileContentsComposedFromRequest(t *testing.T) {
+	// Headline scenario: compose the file path from a route path param and a JSON body
+	// value nested inside file.contents, end-to-end through Eval.
+	content := []byte("id,name\n1,arquivo")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	if err := os.MkdirAll(filepath.Join(dir, "acme", "exemplos"), 0777); err != nil {
+		t.Errorf("Error creating nested folder")
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "acme", "exemplos", "exemplo.csv"), content, 0666); err != nil {
+		t.Errorf("Error updating temporary file")
+	}
+
+	req := mock.Request{Path: "/blu365-athena-results/acme/athena-results/x.csv"}
+	req.Body = `{"name":"exemplo"}`
+	req.Headers = mock.Values{"Content-Type": {"application/json"}}
+
+	res := mock.Response{}
+	res.Body = fmt.Sprintf("{{ file.contents(%s/{{request.path.tenant}}/exemplos/{{request.body.name}}.csv) }}", dir)
+
+	mock := mock.Definition{Request: mock.Request{Path: "/blu365-athena-results/:tenant/athena-results/:filename"}, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != "id,name\n1,arquivo" {
+		t.Errorf("Composed file.contents was not resolved. Got: %s", mock.Response.Body)
+	}
+}
+
+func TestEvalStreamTagAlongsideRequestTag(t *testing.T) {
+	// A stream tag and a sibling {{request.*}} tag on the same body must coexist: the
+	// stream scanner resolves the former in phase A, the generic tokenizer the latter.
+	content := []byte("FILE")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	tmpfn := filepath.Join(dir, "data")
+	if err := ioutil.WriteFile(tmpfn, content, 0666); err != nil {
+		t.Errorf("Error updating temporary file")
+	}
+
+	req := mock.Request{Path: "/results"}
+	req.Body = `{"name":"exemplo"}`
+	req.Headers = mock.Values{"Content-Type": {"application/json"}}
+
+	res := mock.Response{}
+	res.Body = fmt.Sprintf("{{ file.contents(%s) }} name={{request.body.name}}", tmpfn)
+
+	mock := mock.Definition{Request: mock.Request{Path: "/results"}, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != "FILE name=exemplo" {
+		t.Errorf("Stream tag and request tag did not coexist. Got: %s", mock.Response.Body)
+	}
+}

--- a/pkg/vars/filler.go
+++ b/pkg/vars/filler.go
@@ -12,7 +12,7 @@ type Filler interface {
 type FillerFactory interface {
 	CreateRequestFiller(req *mock.Request, mock *mock.Definition) Filler
 	CreateFakeFiller() Filler
-	CreateStreamFiller() Filler
+	CreateStreamFiller(req *mock.Request, mock *mock.Definition) Filler
 }
 
 type MockFillerFactory struct {
@@ -32,6 +32,6 @@ func (mff MockFillerFactory) CreateFakeFiller() Filler {
 	return Fake{Fake: mff.FakeDataProvider}
 }
 
-func (mff MockFillerFactory) CreateStreamFiller() Filler {
-	return Stream{}
+func (mff MockFillerFactory) CreateStreamFiller(req *mock.Request, mock *mock.Definition) Filler {
+	return Stream{Mock: mock, Request: req}
 }

--- a/pkg/vars/request.go
+++ b/pkg/vars/request.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	xj "github.com/basgys/goxml2json"
+	"github.com/jmartin82/mmock/v3/pkg/match/payload"
 	"github.com/jmartin82/mmock/v3/pkg/mock"
 	"github.com/jmartin82/mmock/v3/pkg/route"
 	"github.com/tidwall/gjson"
@@ -169,15 +170,13 @@ func (rp Request) getHeaderParam(name string) (string, bool) {
 }
 
 func (rp Request) getBodyParam(name string) (string, bool) {
-	contentType, found := rp.Request.Headers["Content-Type"]
-	if !found {
-		return "", false
-	}
-	if strings.HasPrefix(contentType[0], "application/x-www-form-urlencoded") {
+	sniffer := payload.NewContentTypeSniffer()
+
+	if sniffer.IsFormEncoded(rp.Request.Headers, rp.Request.Body) {
 		return rp.getUrlEncodedFormBodyParam(name)
-	} else if strings.HasPrefix(contentType[0], "application/xml") || strings.HasPrefix(contentType[0], "text/xml") {
+	} else if sniffer.IsXML(rp.Request.Headers, rp.Request.Body) {
 		return rp.getXmlBodyParam(rp.Request.Body, name)
-	} else if strings.HasPrefix(contentType[0], "application/") && strings.HasSuffix(contentType[0], "json") {
+	} else if sniffer.IsJSON(rp.Request.Headers, rp.Request.Body) {
 		return rp.getJsonBodyParam(rp.Request.Body, name)
 	}
 

--- a/pkg/vars/request.go
+++ b/pkg/vars/request.go
@@ -121,6 +121,9 @@ func (rp Request) getPathParam(name string) (string, bool) {
 
 	route := route.NewRoute(rp.Mock.Request.Path)
 	mparm := route.Match(rp.Request.Path)
+	if mparm == nil {
+		return "", false
+	}
 
 	value, f := mparm.Params[name]
 	if !f {

--- a/pkg/vars/request_test.go
+++ b/pkg/vars/request_test.go
@@ -148,6 +148,49 @@ func TestGetBodyParam(t *testing.T) {
 	}
 }
 
+func TestGetBodyParamWithoutContentType(t *testing.T) {
+	req := mock.Request{}
+	req.Headers = make(mock.Values)
+	// No Content-Type header
+	req.Body = `
+{
+  "name": "john",
+  "age": 30
+}
+`
+	res := mock.Response{}
+	res.Body = `{"name": "{{request.body.name}}", "age": {{request.body.age}}}`
+
+	expected := `{"name": "john", "age": 30}`
+
+	mock := mock.Definition{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != expected {
+		t.Errorf("Failed to resolve body vars without content-type. Got: %s, Expected: %s", mock.Response.Body, expected)
+	}
+}
+
+func TestGetBodyParamWithBinaryContentType(t *testing.T) {
+	req := mock.Request{}
+	req.Headers = make(mock.Values)
+	req.Headers["Content-Type"] = []string{"application/octet-stream"}
+	req.Body = `{"name": "john"}`
+	res := mock.Response{}
+	res.Body = `{"name": "{{request.body.name}}"}`
+
+	expected := `{"name": "john"}`
+
+	mock := mock.Definition{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != expected {
+		t.Errorf("Failed to resolve body vars with application/octet-stream. Got: %s, Expected: %s", mock.Response.Body, expected)
+	}
+}
+
 func TestURI(t *testing.T) {
 	const MOCK_URI = "Test_URI.yml"
 	const MOCK_HEADER_NAME = "x-test-uri"

--- a/pkg/vars/request_test.go
+++ b/pkg/vars/request_test.go
@@ -191,6 +191,45 @@ func TestGetBodyParamWithBinaryContentType(t *testing.T) {
 	}
 }
 
+func TestGetBodyParamWithAwsJsonContentType(t *testing.T) {
+	req := mock.Request{}
+	req.Headers = make(mock.Values)
+	req.Headers["Content-Type"] = []string{"application/x-amz-json-1.1"}
+	req.Body = `{"QueryExecutionContext":{"Database":"operacional_blu"}}`
+	res := mock.Response{}
+	res.Body = `{"QueryExecutionId": "{{request.body.QueryExecutionContext.Database}}"}`
+
+	expected := `{"QueryExecutionId": "operacional_blu"}`
+
+	mock := mock.Definition{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != expected {
+		t.Errorf("Failed to resolve body vars with application/x-amz-json-1.1. Got: %s, Expected: %s", mock.Response.Body, expected)
+	}
+}
+
+func TestGetBodyParamWithWrongContentType(t *testing.T) {
+	req := mock.Request{}
+	req.Headers = make(mock.Values)
+	// Legacy client reporting the wrong content type for a JSON body
+	req.Headers["Content-Type"] = []string{"application/text"}
+	req.Body = `{"name": "john", "age": 30}`
+	res := mock.Response{}
+	res.Body = `{"name": "{{request.body.name}}", "age": {{request.body.age}}}`
+
+	expected := `{"name": "john", "age": 30}`
+
+	mock := mock.Definition{Request: req, Response: res}
+	varsProcessor := getProcessor()
+	varsProcessor.Eval(&req, &mock)
+
+	if mock.Response.Body != expected {
+		t.Errorf("Failed to resolve body vars with wrong content-type. Got: %s, Expected: %s", mock.Response.Body, expected)
+	}
+}
+
 func TestURI(t *testing.T) {
 	const MOCK_URI = "Test_URI.yml"
 	const MOCK_HEADER_NAME = "x-test-uri"

--- a/pkg/vars/stream.go
+++ b/pkg/vars/stream.go
@@ -3,6 +3,7 @@ package vars
 import (
 	"fmt"
 	"github.com/jmartin82/mmock/v3/internal/config/logger"
+	"github.com/jmartin82/mmock/v3/pkg/mock"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -14,6 +15,8 @@ var log = logger.Log
 var re = regexp.MustCompile(`(?m)\((.*)\)`)
 
 type Stream struct {
+	Mock    *mock.Definition
+	Request *mock.Request
 }
 
 func (st Stream) Fill(holders []string) map[string][]string {
@@ -39,12 +42,12 @@ func (st Stream) getOutput(o []byte, err error) string {
 }
 
 func (st Stream) getFileContents(tag string) ([]byte, error) {
-	path := st.getInputParam(tag)
+	path := st.getInputParam(tag, true)
 	return ioutil.ReadFile(path)
 }
 
 func (st Stream) getHttpContents(tag string) ([]byte, error) {
-	url := st.getInputParam(tag)
+	url := st.getInputParam(tag, false)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -57,10 +60,54 @@ func (st Stream) getHttpContents(tag string) ([]byte, error) {
 	return content, nil
 }
 
-func (st Stream) getInputParam(param string) string {
+func (st Stream) getInputParam(param string, forFilePath bool) string {
 	match := re.FindStringSubmatch(param)
 	if len(match) > 1 {
-		return match[1]
+		return st.resolveRequestVars(match[1], forFilePath)
 	}
 	return ""
+}
+
+// resolveRequestVars replaces {{request.*}} holders inside a stream argument using
+// the same extraction logic as the response templating (path params, JSON body via
+// gjson, query params, etc.), so a file path can be composed from request values
+// (e.g. file.contents(/data/{{request.path.tenant}}/{{request.body.name}}.csv)).
+//
+// It is a no-op without request context or holders, so literal paths keep working.
+// Interpolation is enabled only for file paths: http.contents URLs are left literal
+// to avoid introducing an SSRF surface from client-controlled request data.
+func (st Stream) resolveRequestVars(input string, forFilePath bool) string {
+	if !forFilePath {
+		return input
+	}
+	if st.Mock == nil || st.Request == nil || !strings.Contains(input, "{{") {
+		return input
+	}
+
+	rp := Request{Mock: st.Mock, Request: st.Request}
+
+	return varsRegex.ReplaceAllStringFunc(input, func(match string) string {
+		token := strings.Trim(match, "{} ")
+		if !strings.HasPrefix(token, "request.") {
+			return match
+		}
+
+		values, found := rp.Fill([]string{token})[token]
+		if !found || len(values) == 0 {
+			return match
+		}
+
+		// Reject values that are not a single, safe path segment (path separators
+		// or traversal tokens) so a crafted request cannot escape the base directory.
+		if value := values[0]; isSafePathSegment(value) {
+			return value
+		}
+		return match
+	})
+}
+
+// isSafePathSegment reports whether s is a single path segment safe to embed in a
+// file path: it contains no path separator and is not a directory traversal token.
+func isSafePathSegment(s string) bool {
+	return s != "." && s != ".." && !strings.ContainsAny(s, `/\`)
 }

--- a/pkg/vars/stream_test.go
+++ b/pkg/vars/stream_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jmartin82/mmock/v3/pkg/mock"
 )
 
 func TestReadFile(t *testing.T) {
@@ -41,6 +43,181 @@ func TestReadFile(t *testing.T) {
 		t.Errorf("Couldn't get the content. Value: %s", v)
 	}
 
+}
+
+func TestStreamPathParamOnly(t *testing.T) {
+	content := []byte("csv content for arquivo")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "arquivo.csv"), content, 0666); err != nil {
+		t.Errorf("Error creating temporary file")
+	}
+
+	req := &mock.Request{Path: "/results/arquivo.csv"}
+	def := &mock.Definition{Request: mock.Request{Path: "/results/:filename"}}
+	st := Stream{Mock: def, Request: req}
+
+	k := fmt.Sprintf("file.contents(%s/{{request.path.filename}})", dir)
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "csv content for arquivo") {
+		t.Errorf("Path param was not resolved. Value: %s", result[k])
+	}
+}
+
+func TestStreamBodyJSONOnly(t *testing.T) {
+	content := []byte("body json content")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "exemplo.csv"), content, 0666); err != nil {
+		t.Errorf("Error creating temporary file")
+	}
+
+	req := &mock.Request{Path: "/results"}
+	req.Body = `{"name":"exemplo"}`
+	req.Headers = mock.Values{"Content-Type": {"application/json"}}
+	def := &mock.Definition{Request: mock.Request{Path: "/results"}}
+	st := Stream{Mock: def, Request: req}
+
+	k := fmt.Sprintf("file.contents(%s/{{request.body.name}}.csv)", dir)
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "body json content") {
+		t.Errorf("Body JSON value was not resolved. Value: %s", result[k])
+	}
+}
+
+func TestStreamCombinedPathAndBody(t *testing.T) {
+	content := []byte("combined content")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	if err := os.MkdirAll(filepath.Join(dir, "acme", "exemplos"), 0777); err != nil {
+		t.Errorf("Error creating nested folder")
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "acme", "exemplos", "exemplo.csv"), content, 0666); err != nil {
+		t.Errorf("Error creating temporary file")
+	}
+
+	req := &mock.Request{Path: "/blu365-athena-results/acme/athena-results/x.csv"}
+	req.Body = `{"name":"exemplo"}`
+	req.Headers = mock.Values{"Content-Type": {"application/json"}}
+	def := &mock.Definition{Request: mock.Request{Path: "/blu365-athena-results/:tenant/athena-results/:filename"}}
+	st := Stream{Mock: def, Request: req}
+
+	k := fmt.Sprintf("file.contents(%s/{{request.path.tenant}}/exemplos/{{request.body.name}}.csv)", dir)
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "combined content") {
+		t.Errorf("Combined path+body was not resolved. Value: %s", result[k])
+	}
+}
+
+func TestStreamQueryParam(t *testing.T) {
+	content := []byte("query content")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "exemplo.csv"), content, 0666); err != nil {
+		t.Errorf("Error creating temporary file")
+	}
+
+	req := &mock.Request{Path: "/results"}
+	req.QueryStringParameters = mock.Values{"name": {"exemplo"}}
+	def := &mock.Definition{Request: mock.Request{Path: "/results"}}
+	st := Stream{Mock: def, Request: req}
+
+	k := fmt.Sprintf("file.contents(%s/{{request.query.name}}.csv)", dir)
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "query content") {
+		t.Errorf("Query param was not resolved. Value: %s", result[k])
+	}
+}
+
+func TestStreamBodyValueTraversalRejected(t *testing.T) {
+	// A body value resolving to a traversal token must not be substituted; the literal
+	// holder is kept so no parent directory can be reached.
+	req := &mock.Request{Path: "/results"}
+	req.Body = `{"name":".."}`
+	req.Headers = mock.Values{"Content-Type": {"application/json"}}
+	def := &mock.Definition{Request: mock.Request{Path: "/results"}}
+	st := Stream{Mock: def, Request: req}
+
+	k := "file.contents(/data/base/{{request.body.name}}.csv)"
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "{{request.body.name}}") {
+		t.Errorf("Traversal value was substituted instead of rejected. Value: %s", result[k])
+	}
+}
+
+func TestStreamGjsonRegexArgParens(t *testing.T) {
+	// The argument contains gjson .regex(...)/.concat(...) with parentheses and a {4}
+	// quantifier; it must resolve via the gjson chain (README example semantics).
+	content := []byte("regex chain content")
+	dir, err := ioutil.TempDir("", "mmock")
+	if err != nil {
+		t.Errorf("Error creating temporary folder")
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "2307-x.csv"), content, 0666); err != nil {
+		t.Errorf("Error creating temporary file")
+	}
+
+	req := &mock.Request{Path: "/results"}
+	req.Body = `{"uuid":"0bd74115-2307-458f-8288-b726724045ef"}`
+	req.Headers = mock.Values{"Content-Type": {"application/json"}}
+	def := &mock.Definition{Request: mock.Request{Path: "/results"}}
+	st := Stream{Mock: def, Request: req}
+
+	k := fmt.Sprintf(`file.contents(%s/{{request.body.uuid.regex(\b([0-9a-zA-Z]{4})\b).concat(-x)}}.csv)`, dir)
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "regex chain content") {
+		t.Errorf("gjson regex/concat chain was not resolved. Value: %s", result[k])
+	}
+}
+
+func TestStreamHTTPContentsUnchanged(t *testing.T) {
+	// http.contents URLs are kept literal even with request context, to avoid an SSRF
+	// surface: a {{request.*}} in the URL must NOT be interpolated.
+	req := &mock.Request{Path: "/results/acme"}
+	def := &mock.Definition{Request: mock.Request{Path: "/results/:tenant"}}
+	st := Stream{Mock: def, Request: req}
+
+	got := st.getInputParam("http.contents(http://example.com/{{request.path.tenant}}/data)", false)
+	want := "http://example.com/{{request.path.tenant}}/data"
+	if got != want {
+		t.Errorf("http.contents URL should stay literal. Got: %q, want: %q", got, want)
+	}
+}
+
+func TestStreamLiteralPathBackwardCompatible(t *testing.T) {
+	// With no request context, holders must stay literal (no panic, no substitution).
+	st := Stream{}
+
+	k := "file.contents(/data/{{request.path.x}})"
+	result := st.Fill([]string{k})
+
+	if !strings.Contains(result[k][0], "{{request.path.x}}") {
+		t.Errorf("Literal path was not preserved. Value: %s", result[k])
+	}
 }
 
 func TestHTTPContent(t *testing.T) {


### PR DESCRIPTION
Hi @jmartin82 
Certain applications, like aws-cli, sometimes do not send the HTTP Content-Type header, breaking mmock's ability to use the proper comparator or variable references in the response. This pull request adds a basic content-sniff strategy when the Content-Type header is absent to detect payloads in JSON or XML and still use the proper match/var classes.

Also, I noticed some minor issues in your Dockerfile and Makefile that prevent it from working on my Linux-based systems.

Since I wasn't sure if changing those files could break something, I'm sharing below a custom Dockerfile I've made to build the container image properly in stages. It builds the UI in a Node stage, then builds mmock in a second stage, and then the final container.

Hope you find these ideas useful. Thanks for sharing such a great software!

```Dockerfile
# Stage 1: Build the UI
# Using node instead of bun as the project uses npm and to ensure compatibility
FROM node:20-alpine AS ui-builder
WORKDIR /app
COPY UI ./UI
WORKDIR /app/UI
# Creating the output directory explicitly to avoid permission issues with strict environments, 
# though usually not needed if parent is writable.
RUN npm install
RUN npm run build
# The build output goes to ../internal/console/ui relative to specific directory, so /app/internal/console/ui

# Stage 2: Build the Go binary
FROM golang:1.23-alpine AS builder

# Install required tools (git is often needed for go mod download if deps are not vendored)
RUN apk add --no-cache git

WORKDIR /app

# Copy source code
COPY . .

# Copy built UI assets from the previous stage to the correct location for embedding
# We overwrite the local empty/stale directory with the fresh build
COPY --from=ui-builder /app/internal/console/ui ./internal/console/ui

# Run checks and build
RUN go fmt ./...
RUN go test -v ./...
# CGO_ENABLED=0 creates a statically linked binary. 
# While Alpine-to-Alpine dynamic linking usually works, static linking is safer,
# ensuring the binary has zero system dependencies (no glibc/musl mismatch risk ever).
RUN CGO_ENABLED=0 go build -v -o ./bin/mmock cmd/mmock/main.go

# Stage 3: Final Image
FROM alpine:3.20

RUN apk --no-cache add \
    ca-certificates curl

RUN mkdir /config
RUN mkdir /tls

VOLUME /config

# Copy artifacts from builder stage (Stage 2) matches the path structure
COPY --from=builder /app/tls/server.crt /tls/server.crt
COPY --from=builder /app/tls/server.key /tls/server.key
COPY --from=builder /app/bin/mmock /usr/local/bin/mmock

EXPOSE 8082 8083 8084

ENTRYPOINT ["mmock","-config-path","/config","-tls-path","/tls"]
CMD ["-server-ip","0.0.0.0","-console-ip","0.0.0.0"]
HEALTHCHECK --interval=30s --timeout=3s --start-period=3s --retries=2 CMD curl -fsS http://localhost:8082 || exit 1
```
